### PR TITLE
Set LINK_LIBRARIES to CMAKE_EXE_LINKER_FLAGS in final-support.cmake.

### DIFF
--- a/cmake/final-support.cmake
+++ b/cmake/final-support.cmake
@@ -22,6 +22,7 @@ macro( check_final_support_case case )
                  ${CMAKE_CURRENT_BINARY_DIR}
                  ${CMAKE_CURRENT_BINARY_DIR}/fckit-test-${case}.F90
                  COMPILE_DEFINITIONS -D${case}
+                 LINK_LIBRARIES "${CMAKE_EXE_LINKER_FLAGS}"
                  OUTPUT_VARIABLE FCKIT_${case}_compile_output
                  COPY_FILE ${CMAKE_CURRENT_BINARY_DIR}/${case}.bin )
 


### PR DESCRIPTION
Set LINK_LIBRARIES to CMAKE_EXE_LINKER_FLAGS in final-support.cmake. Setting of e.g. rpath in CMAKE_EXE_LINKER_FLAGS may be necessary for an executable to run; this allows such settings to be passed to the compilation of the test executable.