### PR TITLE
Fix char sizes

### DIFF
--- a/src/fckit/module/fckit_configuration.cc
+++ b/src/fckit/module/fckit_configuration.cc
@@ -275,7 +275,7 @@ int32 c_fckit_configuration_get_string( const Configuration* This, const char* n
         return false;
     }
     size  = s.size() + 1;
-    value = new char[size + 1];
+    value = new char[size];
     strcpy( value, s.c_str() );
     return true;
 }

--- a/src/fckit/module/fckit_configuration.cc
+++ b/src/fckit/module/fckit_configuration.cc
@@ -275,7 +275,7 @@ int32 c_fckit_configuration_get_string( const Configuration* This, const char* n
         return false;
     }
     size  = s.size() + 1;
-    value = new char[size];
+    value = new char[size + 1];
     strcpy( value, s.c_str() );
     return true;
 }
@@ -342,7 +342,7 @@ int32 c_fckit_configuration_get_array_string( const Configuration* This, const c
         offsets[j] = size;
         size += s[j].size();
     }
-    value = new char[size];
+    value = new char[size + 1];
     for ( size_t j = 0; j < numelem; ++j ) {
         strcpy( &value[offsets[j]], s[j].c_str() );
     }


### PR DESCRIPTION
Hi @wdeconinck. We had some annoying random tests failure because of memory issues at JCSDA, and it seems that the reason is a simple allocation size in `fckit_configuration.cc`.

I don't know why, but the `char` arrays need to be allocated with `n+1` elements instead of `n` in Fortran. It was done at line 367 for `c_fckit_configuration_json`:
```
    json            = new char[size + 1];
```
but not yet at lines 278 and 345 for `c_fckit_configuration_get_string` and `c_fckit_configuration_get_array_string`.

If you think this bugfix makes sense, we would appreciate a quick merge since we would like to synchronize our `develop` branch with yours as soon as possible. Thanks!