### PR TITLE
Fypp NO_LINE_NUMBERING option

### DIFF
--- a/cmake/fckit_preprocess_fypp.cmake
+++ b/cmake/fckit_preprocess_fypp.cmake
@@ -218,12 +218,20 @@ function( fckit_target_preprocess_fypp _PAR_TARGET )
 
       fckit_target_append_fypp_args( args ${_PAR_TARGET} )
 
-      fckit_preprocess_fypp_sources( preprocessed_sources
-          SOURCES ${sources_to_be_preprocessed}
-          FYPP_ARGS ${_PAR_FYPP_ARGS} ${args}
-          DEPENDS ${preprocessed_depends} ${_PAR_DEPENDS}
-      )
-
+      if( _PAR_NO_LINE_NUMBERING )
+        fckit_preprocess_fypp_sources( preprocessed_sources
+            SOURCES ${sources_to_be_preprocessed}
+            NO_LINE_NUMBERING
+            FYPP_ARGS ${_PAR_FYPP_ARGS} ${args}
+            DEPENDS ${preprocessed_depends} ${_PAR_DEPENDS}
+        )
+      else()
+        fckit_preprocess_fypp_sources( preprocessed_sources
+            SOURCES ${sources_to_be_preprocessed}
+            FYPP_ARGS ${_PAR_FYPP_ARGS} ${args}
+            DEPENDS ${preprocessed_depends} ${_PAR_DEPENDS}
+        )
+      endif()
       target_sources( ${_PAR_TARGET} PRIVATE ${preprocessed_sources} )
 
       ### Extra stuff required to add correct flags


### PR DESCRIPTION
I noticed that the `NO_LINE_NUMBERING` option for the FYPP preprocessor was not passed correctly from `fckit_target_preprocess_fypp` to `fckit_preprocess_fypp_sources`. This PR is a possible bugfix, but there might be other more elegant implementations, I'm not a CMake specialist...