### PR TITLE
Add verbose output stream

### DIFF
--- a/src/fckit/Log.cc
+++ b/src/fckit/Log.cc
@@ -100,7 +100,8 @@ LogTarget* createStyleTarget( LogTarget* target, Log::Style style, const char* p
 void Log::addFortranUnit( int unit, Style style, const char* ) {
     LogTarget* funit = new FortranUnitTarget( unit );
     info().addTarget( createStyleTarget( funit, style, "(I)" ) );
-    verbose().addTarget( createStyleTarget( funit, style, "(V)" ) );
+    if ( Main::instance().verbose() )
+        verbose().addTarget( createStyleTarget( funit, style, "(V)" ) );
     warning().addTarget( createStyleTarget( funit, style, "(W)" ) );
     error().addTarget( createStyleTarget( funit, style, "(E)" ) );
     if ( Main::instance().debug() )
@@ -110,7 +111,8 @@ void Log::addFortranUnit( int unit, Style style, const char* ) {
 void Log::setFortranUnit( int unit, Style style, const char* ) {
     LogTarget* funit = new FortranUnitTarget( unit );
     info().setTarget( createStyleTarget( funit, style, "(I)" ) );
-    verbose().setTarget( createStyleTarget( funit, style, "(V)" ) );
+    if ( Main::instance().verbose() )
+        verbose().setTarget( createStyleTarget( funit, style, "(V)" ) );
     warning().setTarget( createStyleTarget( funit, style, "(W)" ) );
     error().setTarget( createStyleTarget( funit, style, "(E)" ) );
     if ( Main::instance().debug() )
@@ -121,7 +123,8 @@ void Log::setFortranUnit( int unit, Style style, const char* ) {
 void Log::addFile( const char* path, Style style, const char* ) {
     LogTarget* file = new eckit::FileTarget( path );
     info().addTarget( createStyleTarget( file, style, "(I)" ) );
-    verbose().addTarget( createStyleTarget( file, style, "(V)" ) );
+    if ( Main::instance().verbose() )
+        verbose().addTarget( createStyleTarget( file, style, "(V)" ) );
     warning().addTarget( createStyleTarget( file, style, "(W)" ) );
     error().addTarget( createStyleTarget( file, style, "(E)" ) );
     if ( Main::instance().debug() )
@@ -131,7 +134,8 @@ void Log::addFile( const char* path, Style style, const char* ) {
 void Log::setFile( const char* path, Style style, const char* ) {
     LogTarget* file = new eckit::FileTarget( path );
     info().setTarget( createStyleTarget( file, style, "(I)" ) );
-    verbose().setTarget( createStyleTarget( file, style, "(V)" ) );
+    if ( Main::instance().verbose() )
+        verbose().setTarget( createStyleTarget( file, style, "(V)" ) );
     warning().setTarget( createStyleTarget( file, style, "(W)" ) );
     error().setTarget( createStyleTarget( file, style, "(E)" ) );
     if ( Main::instance().debug() )

--- a/src/fckit/Log.cc
+++ b/src/fckit/Log.cc
@@ -100,6 +100,7 @@ LogTarget* createStyleTarget( LogTarget* target, Log::Style style, const char* p
 void Log::addFortranUnit( int unit, Style style, const char* ) {
     LogTarget* funit = new FortranUnitTarget( unit );
     info().addTarget( createStyleTarget( funit, style, "(I)" ) );
+    verbose().addTarget( createStyleTarget( funit, style, "(V)" ) );
     warning().addTarget( createStyleTarget( funit, style, "(W)" ) );
     error().addTarget( createStyleTarget( funit, style, "(E)" ) );
     if ( Main::instance().debug() )
@@ -109,6 +110,7 @@ void Log::addFortranUnit( int unit, Style style, const char* ) {
 void Log::setFortranUnit( int unit, Style style, const char* ) {
     LogTarget* funit = new FortranUnitTarget( unit );
     info().setTarget( createStyleTarget( funit, style, "(I)" ) );
+    verbose().setTarget( createStyleTarget( funit, style, "(V)" ) );
     warning().setTarget( createStyleTarget( funit, style, "(W)" ) );
     error().setTarget( createStyleTarget( funit, style, "(E)" ) );
     if ( Main::instance().debug() )
@@ -119,6 +121,7 @@ void Log::setFortranUnit( int unit, Style style, const char* ) {
 void Log::addFile( const char* path, Style style, const char* ) {
     LogTarget* file = new eckit::FileTarget( path );
     info().addTarget( createStyleTarget( file, style, "(I)" ) );
+    verbose().addTarget( createStyleTarget( file, style, "(V)" ) );
     warning().addTarget( createStyleTarget( file, style, "(W)" ) );
     error().addTarget( createStyleTarget( file, style, "(E)" ) );
     if ( Main::instance().debug() )
@@ -128,6 +131,7 @@ void Log::addFile( const char* path, Style style, const char* ) {
 void Log::setFile( const char* path, Style style, const char* ) {
     LogTarget* file = new eckit::FileTarget( path );
     info().setTarget( createStyleTarget( file, style, "(I)" ) );
+    verbose().setTarget( createStyleTarget( file, style, "(V)" ) );
     warning().setTarget( createStyleTarget( file, style, "(W)" ) );
     error().setTarget( createStyleTarget( file, style, "(E)" ) );
     if ( Main::instance().debug() )

--- a/src/fckit/module/fckit_log.F90
+++ b/src/fckit/module/fckit_log.F90
@@ -39,6 +39,7 @@ type, FORD_PRIVATE :: fckit_log_type
     !!    (W) --> warning
     !!    (E) --> error
     !!    (D) --> debug
+    !!    (V) --> verbose
 
   integer(c_int32_t) :: TIMESTAMP = 2
     !! Style for logging with prefix that contains time stamp and taskID
@@ -47,6 +48,7 @@ type, FORD_PRIVATE :: fckit_log_type
     !!    <taskID> <TIME> (W) --> warning
     !!    <taskID> <TIME> (E) --> error
     !!    <taskID> <TIME> (D) --> debug
+    !!    <taskID> <TIME> (V) --> verbose
 
 contains
 
@@ -55,6 +57,9 @@ contains
 
   procedure, nopass, public :: info
     !! Log to info channel
+
+  procedure, nopass, public :: verbose
+    !! Log to verbose channel
 
   procedure, nopass, public :: warning
     !! Log to warning channel
@@ -96,6 +101,9 @@ contains
   procedure, nopass, public :: info_channel
     !! Return the info [[fckit_logchannel(type)]]
 
+  procedure, nopass, public :: verbose_channel
+    !! Return the verbose [[fckit_logchannel(type)]]
+
   procedure, nopass, public :: warning_channel
     !! Return the warning [[fckit_logchannel(type)]]
 
@@ -118,7 +126,7 @@ type(fckit_log_type) :: log
 !------------------------------------------------------------------------------
 
 type, extends(fckit_object) :: fckit_logchannel
-  !! Log channel (any of info, warning, error, debug)
+  !! Log channel (any of info, verbose, warning, error, debug)
   !!
   !! Wraps ```eckit::Channel```. This channel can be passed as
   !! arguments to functions that expect a ```std::ostream``` to log to.
@@ -164,6 +172,24 @@ subroutine info(msg,newl,flush)
   opt_newl  = 1 ; if( present(newl) ) then; if( .not.  newl ) opt_newl  = 0; endif
   opt_flush = 1 ; if( present(flush)) then; if( .not. flush ) opt_flush = 0; endif
   call fckit__log_info(c_str_right_trim(msg),opt_newl,opt_flush)
+end subroutine
+
+
+subroutine verbose(msg,newl,flush)
+  use, intrinsic :: iso_c_binding
+  use fckit_c_interop_module, only : c_str_right_trim
+  character(kind=c_char,len=*), intent(in) :: msg
+    !! Message to be logged
+  logical, intent(in), optional :: newl
+    !! Add newline character (```\n```) after message.
+    !! Default ```.true.```
+  logical, intent(in), optional :: flush
+    !! Flush channel after message.
+    !! Default ```.true.```
+  integer(c_int32_t) :: opt_newl, opt_flush
+  opt_newl  = 1 ; if( present(newl) ) then; if( .not.  newl ) opt_newl  = 0; endif
+  opt_flush = 1 ; if( present(flush)) then; if( .not. flush ) opt_flush = 0; endif
+  call fckit__log_verbose(c_str_right_trim(msg),opt_newl,opt_flush)
 end subroutine
 
 
@@ -322,6 +348,12 @@ end subroutine
 function info_channel() result(channel)
   type(fckit_logchannel) :: channel
   call channel%reset_c_ptr( fckit__log_info_channel() )
+end function
+
+
+function verbose_channel() result(channel)
+  type(fckit_logchannel) :: channel
+  call channel%reset_c_ptr( fckit__log_verbose_channel() )
 end function
 
 

--- a/src/fckit/module/fckit_log.cc
+++ b/src/fckit/module/fckit_log.cc
@@ -39,6 +39,10 @@ void fckit__log_info( char* msg, int32 newl, int32 flush ) {
     fckit__log( &Log::info(), msg, newl, flush );
 }
 
+void fckit__log_verbose( char* msg, int32 newl, int32 flush ) {
+    fckit__log( &Log::verbose(), msg, newl, flush );
+}
+
 void fckit__log_warning( char* msg, int32 newl, int32 flush ) {
     fckit__log( &Log::warning(), msg, newl, flush );
 }
@@ -81,6 +85,10 @@ void fckit__log_flush() {
 
 Channel* fckit__log_info_channel() {
     return &Log::info();
+}
+
+Channel* fckit__log_verbose_channel() {
+    return &Log::verbose();
 }
 
 Channel* fckit__log_warning_channel() {

--- a/src/fckit/module/fckit_log.inc
+++ b/src/fckit/module/fckit_log.inc
@@ -25,6 +25,13 @@ interface
     integer(c_int32_t), value :: newl
     integer(c_int32_t), value :: flush
   end subroutine
+  ! void fckit__log_verbose(char *msg, int newl, int flush)
+  subroutine fckit__log_verbose(msg,newl,flush) bind(c)
+    use, intrinsic :: iso_c_binding , only : c_char, c_int32_t
+    character(kind=c_char), dimension(*) :: msg
+    integer(c_int32_t), value :: newl
+    integer(c_int32_t), value :: flush
+  end subroutine
   ! void fckit__log_warning(char *msg, int newl, int flush)
   subroutine fckit__log_warning(msg,newl,flush) bind(c)
     use, intrinsic :: iso_c_binding , only : c_char, c_int32_t
@@ -74,6 +81,10 @@ interface
   function fckit__log_info_channel() bind(c)
     use, intrinsic :: iso_c_binding, only : c_ptr
     type(c_ptr) :: fckit__log_info_channel
+  end function
+  function fckit__log_verbose_channel() bind(c)
+    use, intrinsic :: iso_c_binding, only : c_ptr
+    type(c_ptr) :: fckit__log_verbose_channel
   end function
   function fckit__log_warning_channel() bind(c)
     use, intrinsic :: iso_c_binding, only : c_ptr

--- a/src/fckit/module/fckit_main.F90
+++ b/src/fckit/module/fckit_main.F90
@@ -199,6 +199,15 @@ function debug()
   if( debug_int==1 ) debug = .true.
 end function
 
+function verbose()
+  use, intrinsic :: iso_c_binding, only : c_int32_t
+  logical :: verbose
+  integer(c_int32_t) :: verbose_int
+  verbose_int = fckit__main_verbose()
+  verbose = .false.
+  if( verbose_int==1 .OR. debug() ) verbose = .true.
+end function
+
 subroutine main_name(name)
   use, intrinsic :: iso_c_binding
   use fckit_c_interop_module

--- a/src/fckit/module/fckit_main.cc
+++ b/src/fckit/module/fckit_main.cc
@@ -71,6 +71,10 @@ int32 fckit__main_debug() {
     return fckit::Log::debug() != 0;
 }
 
+int32 fckit__main_verbose() {
+    return fckit::Log::verbose() != 0;
+}
+
 int32 fckit__main_name( char*& name, size_t& size ) {
     std::string v = fckit::Main::instance().name();
     size          = v.size();

--- a/src/fckit/module/fckit_main.inc
+++ b/src/fckit/module/fckit_main.inc
@@ -51,6 +51,11 @@ interface
     integer(c_int32_t) :: debug
   end function
 
+  function fckit__main_verbose() result(verbose) bind(c)
+    use iso_c_binding, only : c_int32_t
+    integer(c_int32_t) :: verbose
+  end function
+
   !int32 fckit__main_name (char* &name, size_t &name_size)
   function fckit__main_name(name,name_size) result(error_code) bind(c)
     use iso_c_binding, only: c_int32_t, c_size_t, c_ptr


### PR DESCRIPTION
### Description
The debug output stream is useful to track the progress of an application and check the values of quantities used in calculations. However, we have found several cases in which the debug stream can produce an excessive amount of output. This can happen when, for example, it is placed inside a for loop. In a simple unit test there may only be a few lines of output, but in a full operational test that could suddenly turn into thousands of essentially redundant lines.

### Requirements
Produce a new verbose output stream. This will be used for normal diagnostic messages, but will be slightly more verbose than the default channel. It can be switched on by setting the environment variable MAIN_VERBOSE=1. The verbose channel will also be produced if MAIN_DEBUG=1, as we are thinking of a hierarchy of output levels. Thus, the debug output stream can be kept for full debugging output.

### Dependencies
Depends on https://github.com/ecmwf/eckit/pull/43