### PR TITLE
Add condition on array size to avoid address error

### DIFF
--- a/src/fckit/module/fckit_configuration.F90
+++ b/src/fckit/module/fckit_configuration.F90
@@ -601,7 +601,7 @@ function get_config_list(this, name, value) result(found)
   found_int = c_fckit_configuration_get_config_list(this%CPTR_PGIBUG_B, c_str(name), &
     & value_list_cptr, value_list_size)
   found = .False.
-  if( found_int == 1 ) then
+  if( found_int == 1 .and. value_list_size > 0) then
     found = .true.
     call c_f_pointer(value_list_cptr,value_cptrs,(/value_list_size/))
     allocate(value(value_list_size))
@@ -731,7 +731,7 @@ function get_string(this, name, value) result(found)
   integer(c_int32_t) :: found_int
   integer(c_size_t) :: value_size
   found_int = c_fckit_configuration_get_string(this%CPTR_PGIBUG_B,c_str(name),value_cptr,value_size)
-  if( found_int == 1 ) then
+  if( found_int == 1 .and. value_size > 0) then
     if( allocated(value) ) deallocate(value)
     FCKIT_ALLOCATE_CHARACTER(value,value_size)
     value = c_ptr_to_string(value_cptr)
@@ -762,7 +762,7 @@ function get_array_logical(this, name, value) result(found)
   integer(c_int32_t) :: found_int
   found_int = c_fckit_configuration_get_array_int32(this%CPTR_PGIBUG_B, c_str(name), &
    & value_cptr, value_size )
-  if (found_int ==1 ) then
+  if( found_int == 1 .and. value_size > 0) then
     call c_f_pointer(value_cptr,value_fptr,(/value_size/))
     allocate(value_int(value_size))
     value_int(:) = value_fptr(:)
@@ -801,7 +801,7 @@ function get_array_int32(this, name, value) result(found)
   integer(c_int32_t) :: found_int
   found_int = c_fckit_configuration_get_array_int32(this%CPTR_PGIBUG_B, c_str(name), &
    & value_cptr, value_size )
-  if (found_int ==1 ) then
+  if( found_int == 1 .and. value_size > 0) then
     call c_f_pointer(value_cptr,value_fptr,(/value_size/))
     if( allocated(value) ) deallocate(value)
     allocate(value(value_size))
@@ -832,7 +832,7 @@ function get_array_int64(this, name, value) result(found)
   integer(c_int32_t) :: found_int
   found_int = c_fckit_configuration_get_array_int64(this%CPTR_PGIBUG_B, c_str(name), &
    & value_cptr, value_size )
-  if (found_int == 1) then
+  if( found_int == 1 .and. value_size > 0) then
     call c_f_pointer(value_cptr,value_fptr,(/value_size/))
     if( allocated(value) ) deallocate(value)
     allocate(value(value_size))
@@ -863,7 +863,7 @@ function get_array_real32(this, name, value) result(found)
   integer(c_int32_t) :: found_int
   found_int = c_fckit_configuration_get_array_float(this%CPTR_PGIBUG_B, c_str(name), &
    & value_cptr, value_size )
-  if (found_int == 1 ) then
+  if( found_int == 1 .and. value_size > 0) then
     call c_f_pointer(value_cptr,value_fptr,(/value_size/))
     if( allocated(value) ) deallocate(value)
     allocate(value(value_size))
@@ -894,7 +894,7 @@ function get_array_real64(this, name, value) result(found)
   integer(c_int32_t) :: found_int
   found_int = c_fckit_configuration_get_array_double(this%CPTR_PGIBUG_B, c_str(name), &
    & value_cptr, value_size )
-  if (found_int == 1) then
+  if( found_int == 1 .and. value_size > 0) then
     call c_f_pointer(value_cptr,value_fptr,(/value_size/))
     if( allocated(value) ) deallocate(value)
     allocate(value(value_size))
@@ -932,7 +932,7 @@ function get_array_string(this,name,value) result(found)
   character(len=:), allocatable :: flatvalue
   found_int =   c_fckit_configuration_get_array_string(this%CPTR_PGIBUG_B, c_str(name), &
    & value_cptr, value_size, offsets_cptr, value_numelem)
-  if( found_int == 1 ) then
+  if( found_int == 1 .and. value_size > 0) then
     ! Get flat character array
     allocate(character(len=value_size) :: flatvalue )
     flatvalue = c_ptr_to_string(value_cptr)

--- a/src/fckit/module/fckit_configuration.F90
+++ b/src/fckit/module/fckit_configuration.F90
@@ -601,7 +601,7 @@ function get_config_list(this, name, value) result(found)
   found_int = c_fckit_configuration_get_config_list(this%CPTR_PGIBUG_B, c_str(name), &
     & value_list_cptr, value_list_size)
   found = .False.
-  if( found_int == 1 .and. value_list_size > 0) then
+  if( found_int == 1 ) then
     found = .true.
     call c_f_pointer(value_list_cptr,value_cptrs,(/value_list_size/))
     allocate(value(value_list_size))

--- a/src/fckit/module/fckit_configuration.F90
+++ b/src/fckit/module/fckit_configuration.F90
@@ -731,11 +731,13 @@ function get_string(this, name, value) result(found)
   integer(c_int32_t) :: found_int
   integer(c_size_t) :: value_size
   found_int = c_fckit_configuration_get_string(this%CPTR_PGIBUG_B,c_str(name),value_cptr,value_size)
-  if( found_int == 1 .and. value_size > 0) then
+  if( found_int == 1 ) then
     if( allocated(value) ) deallocate(value)
     FCKIT_ALLOCATE_CHARACTER(value,value_size)
-    value = c_ptr_to_string(value_cptr)
-    call c_ptr_free(value_cptr)
+    if ( value_size > 0 ) then
+      value = c_ptr_to_string(value_cptr)
+      call c_ptr_free(value_cptr)
+    endif
   endif
   found = .False.
   if (found_int == 1) found = .True.
@@ -762,7 +764,7 @@ function get_array_logical(this, name, value) result(found)
   integer(c_int32_t) :: found_int
   found_int = c_fckit_configuration_get_array_int32(this%CPTR_PGIBUG_B, c_str(name), &
    & value_cptr, value_size )
-  if( found_int == 1 .and. value_size > 0) then
+  if( found_int == 1 ) then
     call c_f_pointer(value_cptr,value_fptr,(/value_size/))
     allocate(value_int(value_size))
     value_int(:) = value_fptr(:)
@@ -773,7 +775,7 @@ function get_array_logical(this, name, value) result(found)
         value(j) = .True.
       else
         value(j) = .False.
-      end if
+      endif
     end do
     call c_ptr_free(value_cptr)
   endif
@@ -801,7 +803,7 @@ function get_array_int32(this, name, value) result(found)
   integer(c_int32_t) :: found_int
   found_int = c_fckit_configuration_get_array_int32(this%CPTR_PGIBUG_B, c_str(name), &
    & value_cptr, value_size )
-  if( found_int == 1 .and. value_size > 0) then
+  if( found_int == 1 ) then
     call c_f_pointer(value_cptr,value_fptr,(/value_size/))
     if( allocated(value) ) deallocate(value)
     allocate(value(value_size))
@@ -832,7 +834,7 @@ function get_array_int64(this, name, value) result(found)
   integer(c_int32_t) :: found_int
   found_int = c_fckit_configuration_get_array_int64(this%CPTR_PGIBUG_B, c_str(name), &
    & value_cptr, value_size )
-  if( found_int == 1 .and. value_size > 0) then
+  if( found_int == 1 ) then
     call c_f_pointer(value_cptr,value_fptr,(/value_size/))
     if( allocated(value) ) deallocate(value)
     allocate(value(value_size))
@@ -863,7 +865,7 @@ function get_array_real32(this, name, value) result(found)
   integer(c_int32_t) :: found_int
   found_int = c_fckit_configuration_get_array_float(this%CPTR_PGIBUG_B, c_str(name), &
    & value_cptr, value_size )
-  if( found_int == 1 .and. value_size > 0) then
+  if( found_int == 1 ) then
     call c_f_pointer(value_cptr,value_fptr,(/value_size/))
     if( allocated(value) ) deallocate(value)
     allocate(value(value_size))
@@ -894,7 +896,7 @@ function get_array_real64(this, name, value) result(found)
   integer(c_int32_t) :: found_int
   found_int = c_fckit_configuration_get_array_double(this%CPTR_PGIBUG_B, c_str(name), &
    & value_cptr, value_size )
-  if( found_int == 1 .and. value_size > 0) then
+  if( found_int == 1 ) then
     call c_f_pointer(value_cptr,value_fptr,(/value_size/))
     if( allocated(value) ) deallocate(value)
     allocate(value(value_size))
@@ -932,11 +934,13 @@ function get_array_string(this,name,value) result(found)
   character(len=:), allocatable :: flatvalue
   found_int =   c_fckit_configuration_get_array_string(this%CPTR_PGIBUG_B, c_str(name), &
    & value_cptr, value_size, offsets_cptr, value_numelem)
-  if( found_int == 1 .and. value_size > 0) then
+  if( found_int == 1 ) then
     ! Get flat character array
     allocate(character(len=value_size) :: flatvalue )
-    flatvalue = c_ptr_to_string(value_cptr)
-    call c_ptr_free(value_cptr)
+    if ( value_size > 0 ) then
+      flatvalue = c_ptr_to_string(value_cptr)
+      call c_ptr_free(value_cptr)
+    end if
     ! Get offsets
     call c_f_pointer(offsets_cptr,offsets_fptr,(/value_numelem/))
     allocate(offsets(value_numelem))


### PR DESCRIPTION
Simple bugfix to avoid AddressSanitizer errors when a list of configuration items is present but empty.