### PR TITLE
Prevent string out of bounds.

### DIFF
--- a/src/fckit/module/fckit_C_interop.F90
+++ b/src/fckit/module/fckit_C_interop.F90
@@ -193,7 +193,7 @@ function c_ptr_to_string(cptr) result(string)
   type(c_ptr), intent(in) :: cptr
   character(kind=c_char,len=:), allocatable :: string
   character(kind=c_char), dimension(:), pointer  :: s
-  integer(c_int), parameter :: MAX_STR_LEN = 255
+  integer(c_int), parameter :: MAX_STR_LEN = 2550
   call c_f_pointer ( cptr , s, (/MAX_STR_LEN/) )
   call copy_c_str_to_string( s, string )
 end function

--- a/src/fckit/module/fckit_C_interop.F90
+++ b/src/fckit/module/fckit_C_interop.F90
@@ -181,7 +181,7 @@ subroutine copy_c_ptr_to_string(cptr,string)
   type(c_ptr), intent(in) :: cptr
   character(kind=c_char,len=:), allocatable :: string
   character(kind=c_char), dimension(:), pointer  :: s
-  integer(c_int), parameter :: MAX_STR_LEN = 255
+  integer(c_int), parameter :: MAX_STR_LEN = 2550
   call c_f_pointer ( cptr , s, (/MAX_STR_LEN/) )
   call copy_c_str_to_string( s, string )
 end subroutine

--- a/src/fckit/module/fckit_C_interop.F90
+++ b/src/fckit/module/fckit_C_interop.F90
@@ -161,13 +161,11 @@ end function
 
 subroutine copy_c_str_to_string(s,string)
   use, intrinsic :: iso_c_binding
-  character(kind=c_char,len=1), intent(in) :: s(*)
+  character(kind=c_char,len=1), intent(in) :: s(:)
   character(len=:), allocatable :: string
   integer i, nchars
-  i = 1
-  do
+  do i = 1, size(s)
      if (s(i) == c_null_char) exit
-     i = i + 1
   enddo
   nchars = i - 1  ! Exclude null character from Fortran string
   FCKIT_ALLOCATE_CHARACTER(string,nchars)


### PR DESCRIPTION
Resolves #45.  It seems that the code has hardcoded string limits and at some point the strings being passed to fckit are too long for the hardcoded limit.  I don't know where those are coming from, but I think it would be better if the string truncated in that case rather than went out of bounds and did undefined behaviour.

I have done this by turning the dummy argument into an assumed shape array which means its bounds are passed in the subroutine call.  The loop can then have an upper bound which ensures that the array never goes out of bounds.  What do you think?