### PR TITLE
Ensure eckit linked with latest libaec in downstream-ci

### DIFF
--- a/.github/ci-config.yml
+++ b/.github/ci-config.yml
@@ -1,5 +1,6 @@
 dependencies: |
   ecmwf/ecbuild
+  MathisRosenhauer/libaec@master
   ecmwf/eckit
 dependency_branch: develop
 parallelism_factor: 8


### PR DESCRIPTION
When part of the downstream-ci, fckit's ci can sometimes be the place where eckit is built and used later on. When used in gribjump's fdb plugin, it needs to have been built with libaec version 1.1.1 or above, which is not the system version on some of our runners. Therefore if fckit's ci uses the latest libaec, then the eckit that it builds will be correct for packages further downstream.