### PR TITLE
Propagate dependencies of fypp files

### DIFF
--- a/cmake/fckit_preprocess_fypp.cmake
+++ b/cmake/fckit_preprocess_fypp.cmake
@@ -129,10 +129,17 @@ function( fckit_preprocess_fypp_sources output )
       set( short_outfile "${base}.F90")
     endif()
 
+    get_source_file_property( _depends ${filename} OBJECT_DEPENDS )
+
+    unset( ${filename}_depends )
+    if( _depends )
+       set( ${filename}_depends ${_depends} )
+    endif()
+
     add_custom_command(
       OUTPUT ${outfile}
       COMMAND ${CMAKE_COMMAND} -E env FCKIT_EVAL_ARGS_EXCLUDE="${_PAR_FYPP_ARGS_EXCLUDE}" ${FYPP} ${args} ${CMAKE_CURRENT_SOURCE_DIR}/${filename} ${outfile}
-      DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/${filename} ${_PAR_DEPENDS} 
+      DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/${filename} ${_PAR_DEPENDS} ${${filename}_depends}
       COMMENT "[fypp] Preprocessor generating ${short_outfile}" )
 
     set_source_files_properties(${outfile} PROPERTIES GENERATED TRUE)


### PR DESCRIPTION
A new design pattern emerging in the IFS is to place commonly used templates in header files and include these in fypp files. CMake does not of course recognise these fypp header files as dependencies, so changes to the template do not re-trigger fypp pre-processing and re-compilation.

One possible remedy is to manually mark the fypp files as depending on the header files. This PR adds the functionality to propagate this dependency through to the fypp preprocessing.