### PR TITLE
Add support for python3.12 and greater for the fckit venv

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -125,7 +125,7 @@ find_package( Python3 COMPONENTS Interpreter )
 ecbuild_add_option( FEATURE FCKIT_VENV
                     DEFAULT OFF
                     DESCRIPTION "Install Python virtual environment with fypp and a yaml parser"
-                    CONDITION Python3_VERSION VERSION_GREATER_EQUAL 3.8 AND Python3_VERSION VERSION_LESS 3.12 )
+                    CONDITION Python3_VERSION VERSION_GREATER_EQUAL 3.8 )
 
 ecbuild_add_option( FEATURE FCKIT_VENV_OFFLINE
                     DEFAULT OFF

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 ruamel.yaml==0.18.6
 ruamel.yaml.clib==0.2.12
-setuptools==65.5.0
+setuptools==75.0.0
 wheel==0.45.1

--- a/src/fckit/fckit_yaml_reader/pyproject.toml
+++ b/src/fckit/fckit_yaml_reader/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools==65.5.0"]
+requires = ["setuptools==75.0.0"]
 build-backend = "setuptools.build_meta"
 
 [project]


### PR DESCRIPTION
A small PR that upgrades the required setuptools version so as to add support for python3.12 and greater.