### PR TITLE
Added support for COMPILE_OPTIONS to fckit_preprocess_fypp_sources.

### DIFF
--- a/cmake/fckit_preprocess_fypp.cmake
+++ b/cmake/fckit_preprocess_fypp.cmake
@@ -149,6 +149,7 @@ function( fckit_preprocess_fypp_sources output )
     # ecbuild 3.2 compatible properties that need to be transferred from .fypp files to .F90
     foreach( _prop COMPILE_FLAGS
                    COMPILE_FLAGS_${CMAKE_BUILD_TYPE_CAPS}
+                   COMPILE_OPTIONS
                    OVERRIDE_COMPILE_FLAGS
                    OVERRIDE_COMPILE_FLAGS_${CMAKE_BUILD_TYPE_CAPS} )
       get_source_file_property( ${filename}_${_prop} ${filename} ${_prop} )


### PR DESCRIPTION
In CMake `COMPILE_OPTIONS` (https://cmake.org/cmake/help/latest/prop_sf/COMPILE_OPTIONS.html) are nowadays preferred over `COMPILE_FLAGS`. 
Unfortunately, everything that is `fypp`-processed, ignores `COMPILE_OPTIONS` at the moment. I've added `COMPILE_OPTIONS` to the list of properties that is forwarded in this case.