### PR TITLE
Call ensurepip in fckit_install_venv

### DIFF
--- a/cmake/fckit_install_venv.cmake
+++ b/cmake/fckit_install_venv.cmake
@@ -34,6 +34,9 @@ macro( fckit_install_venv )
     # Find newly created python venv
     find_package( Python3 COMPONENTS Interpreter REQUIRED )
 
+    # Make sure the Python installation has (sufficiently recent) pip
+    execute_process( COMMAND ${Python3_EXECUTABLE} -m ensurepip -U OUTPUT_QUIET )
+
     if( Python3_VERSION VERSION_EQUAL 3.8 )
        execute_process( COMMAND ${Python3_EXECUTABLE} -m pip --disable-pip-version-check
                         install --upgrade ${PIP_OPTIONS} pip OUTPUT_QUIET ERROR_QUIET )


### PR DESCRIPTION
Bare metal Python installations may come without the pip module/binaries installed. Python, however, always comes with a method to bootstrap pip in a _fully offline_ fashion (why you wouldn't want to have pip simply installed when this is included anyway, I don't know): https://docs.python.org/3/library/ensurepip.html

The addition in this PR makes sure we have at least the pip version available that is packaged with the relevant Python version.