### PR TITLE
Expose fckit_mpi%finalize()

### DIFF
--- a/src/fckit/module/fckit_mpi.cc
+++ b/src/fckit/module/fckit_mpi.cc
@@ -625,4 +625,8 @@ int32 fckit__mpi__mpi_info_null() {
 #endif
 }
 
+void fckit__mpi__finaliseAllComms() {
+    eckit::mpi::finaliseAllComms();
+}
+
 }  // extern "C"

--- a/src/fckit/module/fckit_mpi.fypp
+++ b/src/fckit/module/fckit_mpi.fypp
@@ -103,6 +103,7 @@ public :: fckit_mpi_comm
 public :: fckit_mpi_status
 public :: fckit_mpi_addComm
 public :: fckit_mpi_setCommDefault
+public :: fckit_mpi_finaliseAllComms
 public :: fckit_mpi_sum
 public :: fckit_mpi_prod
 public :: fckit_mpi_min
@@ -196,6 +197,9 @@ contains
 
   procedure, public :: anysource
     !! anysource
+
+  procedure, public, nopass :: finalize => fckit_mpi_finaliseAllComms
+    !! MPI Finalize
 
   @:begin_interface( allreduce )
   @:generate_interfaces( allreduce )
@@ -538,6 +542,12 @@ interface
     integer(c_int32_t), dimension(*) :: status
   end subroutine
 
+
+  ! void fckit__mpi__finaliseAllComms()
+  subroutine fckit__mpi__finaliseAllComms() bind(c,name="fckit__mpi__finaliseAllComms")
+  end subroutine
+
+
 end interface
 
 !========================================================================
@@ -634,6 +644,12 @@ subroutine fckit_mpi_addComm_name_int(name,comm)
   character(kind=c_char,len=*), intent(in), optional :: name
   integer(c_int32_t), intent(in) :: comm
   call fckit__mpi__addComm_name_int(c_str(name),comm)
+end subroutine
+
+!---------------------------------------------------------------------------------------
+
+subroutine fckit_mpi_finaliseAllComms()
+  call fckit__mpi__finaliseAllComms()
 end subroutine
 
 !---------------------------------------------------------------------------------------


### PR DESCRIPTION
In some cases, e.g. linked with ecmwf/eckit#171 it is advised to finalize MPI before the end of the program.
This can with this PR be done with:
```Fortran
use fckit_module
call fckit_mpi%finalize()
```