### PR TITLE
Populate

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -127,11 +127,6 @@ ecbuild_add_option( FEATURE FCKIT_VENV
                     DESCRIPTION "Install Python virtual environment with fypp and a yaml parser"
                     CONDITION Python3_VERSION VERSION_GREATER_EQUAL 3.8 )
 
-ecbuild_add_option( FEATURE FCKIT_VENV_OFFLINE
-                    DEFAULT OFF
-                    DESCRIPTION "Offline install of fckit Python virtual environment"
-                    CONDITION DEFINED FCKIT_VENV_WHEEL_DIR )
-
 if( HAVE_FCKIT_VENV )
    fckit_install_venv()
 else()

--- a/README.md
+++ b/README.md
@@ -45,24 +45,23 @@ Various Fortran modules helpful to create mixed-language applications
 
 An offline build/installation of the fckit Python virtual environment can be completed as follows:
 
-1. Download all necessary Python dependencies listed in fckit/requirements.txt. `ruamel.yaml.clib`
+1. Download all necessary Python dependencies of src/fckit/fckit_yaml_reader. `ruamel.yaml.clib`
 is not a pure Python package, so we have to ensure a wheel compatible with the target platform is
 downloaded. pip compatibility tags for any system can be displayed using `python3 -m pip debug --verbose`,
 and buit-distributions (i.e. wheels) for ruamel.yaml.clib can be found [here](https://pypi.org/project/ruamel.yaml.clib/#files).
 For a linux installation based on an x86 architecture using Python3.10, the following command can be used:
 
 ```
-python3 -m pip download -r requirements.txt -d <dir-to-store-dependencies> \
---only-binary=:all: --python-version 310 --platform manylinux_2_17_x86_64
+FCKIT_WHEEL_ARCH=manylinux_2_17_x86_64 FCKIT_WHEEL_PYTHON_VERSION=310 ./populate
 ```
+
+This will download all the wheels to `<source-dir>/artifacts.` It should
+be noted that if `FCKIT_WHEEL_ARCH` and `FCKIT_WHEEL_PYTHON_VERSION`
+are not specified then the wheels are downloaded for the calling system's Python interpreter.
 
 2. scp/rsync/copy the directory containing the dependencies to the offline system.
 
-3. Add the following two arguments to the fckit CMake configuration step:
-
-```
--DENABLE_FCKIT_VENV_OFFLINE=ON -DFCKIT_VENV_WHEEL_DIR=<dir-containing-dependencies>
-```
+3. Add the path to the `artifacts` directory to the fckit CMake configuration step, i.e. `-DARTIFACTS_DIR=<path-to-artifacts-dir>`.
 
 ### License
 

--- a/cmake/fckit_download_python_wheels.cmake
+++ b/cmake/fckit_download_python_wheels.cmake
@@ -1,0 +1,137 @@
+# (C) Copyright 2025 ECMWF.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation nor
+# does it submit to any jurisdiction.
+
+##############################################################################
+#.rst:
+#
+# download_python_wheels
+# ======================
+#
+# Download all dependencies for the given ``REQUIREMENT_SPEC`` and cache them in a
+# wheelhouse at ``WHEELS_DIR``
+#
+#   download_python_wheels( REQUIREMENT_SPEC <spec> [ WHEELS_DIR <path> ] [ PYTHON_VERSION <version str> ] 
+#                           [ WHEEL_ARCH <spec> ] [ WHEEL_PYTHON_VERSION <spec> ] )
+#
+# Implementation note
+# -------------------
+#
+# This function does intentionally not expose all PIP options directly because the PIP command line
+# interface allows to specify option values via environment variables. These can therefore be used
+# to further control the PIP behaviour, see https://pip.pypa.io/en/stable/cli/pip_download/
+#
+# Because PIP does not provide a mechanism for downloading PEP 518 build dependencies,
+# this function builds the wheel also for the provided REQUIREMENT_SPEC instead of only downloading
+# the required dependencies. See https://github.com/pypa/pip/issues/7863 for details.
+# To provide a sane minimum, setuptools and wheel packages are always downloaded.
+#
+# The provided PYTHON_VERSION is used to discover a Python interpreter matching the version
+# specification when calling pip. To download wheels for specific platforms or Python versions,
+# use the PIP_PLATFORM, PIP_PYTHON_VERSION, PIP_IMPLEMENTATION, or PIP_ABI environment variables.
+#
+# It is safe to call this function during an offline build, as long as all wheels are already
+# available in the wheelhouse. A dry-run call to ``pip install`` is used to determine the need
+# for any wheel downloads before executing the ``pip download`` command.
+#
+# Options
+# -------
+#
+# :REQUIREMENT_SPEC: The requirement spec as given to ``pip download`` and ``pip wheel``
+# :WHEELS_DIR: The path of the wheelhouse directory to cache the wheels. Defaults to
+#              ``${CMAKE_CURRENT_BINARY_DIR}/wheelhouse``
+# :PYTHON_VERSION: Optional specification of permissible Python versions for find_package
+# :WHEEL_ARCH: Optional specification of architecture for which to download non-pure Python wheels
+# :WHEEL_PYTHON_VERSION: Optional specification of Python version for which to download wheels
+#
+##############################################################################
+
+function( download_python_wheels )
+
+    set( options "" )
+    set( oneValueArgs REQUIREMENT_SPEC WHEELS_DIR PYTHON_VERSION WHEEL_ARCH WHEEL_PYTHON_VERSION )
+    set( multiValueArgs "" )
+
+    cmake_parse_arguments( _PAR "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN} )
+
+    if( _PAR_UNPARSED_ARGUMENTS )
+        message( FATAL_ERROR "Unknown keywords given to download_python_wheels(): \"${_PAR_UNPARSED_ARGUMENTS}\"" )
+    endif()
+
+    if( NOT _PAR_REQUIREMENT_SPEC )
+        message( FATAL_ERROR "No REQUIREMENT_SPEC provided to download_python_wheels()" )
+    endif()
+
+    message( STATUS "Checking for cached wheels in ${WHEELS_DIR}" )
+
+    # Check for a suitable python interpreter
+    find_package( Python3 ${_PAR_PYTHON_VERSION} COMPONENTS Interpreter REQUIRED QUIET )
+
+    # If no wheelhouse dir is given, create one in the current binary directory
+    if( _PAR_WHEELS_DIR )
+        set( WHEELS_DIR "${_PAR_WHEELS_DIR}" )
+    else()
+        set( WHEELS_DIR "${CMAKE_CURRENT_BINARY_DIR}/wheelhouse" )
+    endif()
+    file( MAKE_DIRECTORY "${WHEELS_DIR}" )
+
+    unset( PIP_OPTIONS )
+    if( DEFINED _PAR_WHEEL_ARCH AND NOT _PAR_WHEEL_ARCH MATCHES None|NONE )
+       list( APPEND PIP_OPTIONS "--platform=${_PAR_WHEEL_ARCH}" )
+    endif()
+    if( DEFINED _PAR_WHEEL_PYTHON_VERSION AND NOT _PAR_WHEEL_PYTHON_VERSION MATCHES None|NONE )
+       list( APPEND PIP_OPTIONS "--python-version=${_PAR_WHEEL_PYTHON_VERSION}" )
+    endif()
+
+    # We use a dry-run installation to check if all dependencies have already been downloaded
+    execute_process(
+        COMMAND
+            ${Python3_EXECUTABLE} -m pip install
+                --dry-run --break-system-packages
+                --no-index --find-links "${WHEELS_DIR}" --only-binary :all:
+                ${PIP_OPTIONS}
+                ${_PAR_REQUIREMENT_SPEC}
+        OUTPUT_QUIET ERROR_QUIET
+        RESULT_VARIABLE _RET_VAL
+    )
+
+    if( "${_RET_VAL}" EQUAL "0" )
+
+        message( STATUS "All dependency wheels for ${_PAR_REQUIREMENT_SPEC} found in cache" )
+
+    else()
+
+        message( STATUS "Downloading dependency wheels for ${_PAR_REQUIREMENT_SPEC} to ${WHEELS_DIR}" )
+
+        # Download typical build dependencies for wheels: setuptools and wheel
+        execute_process(
+            COMMAND
+                ${Python3_EXECUTABLE} -m pip download
+                --disable-pip-version-check --only-binary :all: --dest "${WHEELS_DIR}"
+                ${PIP_OPTIONS}
+                setuptools>=75.0.0 wheel
+            OUTPUT_QUIET
+        )
+
+        # Download dependencies for the specified REQUIREMENT_SPEC
+        execute_process(
+            COMMAND
+                ${Python3_EXECUTABLE} -m pip download
+                --disable-pip-version-check --only-binary :all: --dest "${WHEELS_DIR}"
+                ${PIP_OPTIONS}
+                ${_PAR_REQUIREMENT_SPEC}
+            OUTPUT_QUIET
+        )
+
+    endif()
+
+endfunction()
+
+download_python_wheels( REQUIREMENT_SPEC     ${REQUIREMENT_SPEC}
+                        WHEELS_DIR           ${WHEELS_DIR}       
+                        WHEEL_ARCH           ${FCKIT_WHEEL_ARCH}
+                        WHEEL_PYTHON_VERSION ${FCKIT_WHEEL_PYTHON_VERSION} )

--- a/cmake/fckit_download_python_wheels.cmake
+++ b/cmake/fckit_download_python_wheels.cmake
@@ -81,10 +81,12 @@ function( download_python_wheels )
 
     unset( PIP_OPTIONS )
     if( DEFINED _PAR_WHEEL_ARCH AND NOT _PAR_WHEEL_ARCH MATCHES None|NONE )
-       list( APPEND PIP_OPTIONS "--platform=${_PAR_WHEEL_ARCH}" )
+       string(REPLACE "\"" "" _WHEEL_ARCH ${_PAR_WHEEL_ARCH})
+       list( APPEND PIP_OPTIONS "--platform=${_WHEEL_ARCH}" )
     endif()
     if( DEFINED _PAR_WHEEL_PYTHON_VERSION AND NOT _PAR_WHEEL_PYTHON_VERSION MATCHES None|NONE )
-       list( APPEND PIP_OPTIONS "--python-version=${_PAR_WHEEL_PYTHON_VERSION}" )
+       string(REPLACE "\"" "" _PYTHON_VERSION ${_PAR_WHEEL_PYTHON_VERSION})
+       list( APPEND PIP_OPTIONS "--python-version=${_PYTHON_VERSION}" )
     endif()
 
     # We use a dry-run installation to check if all dependencies have already been downloaded

--- a/cmake/fckit_install_venv.cmake
+++ b/cmake/fckit_install_venv.cmake
@@ -15,10 +15,10 @@ macro( fckit_install_venv )
 
     # Make the virtualenv portable by automatically deducing the VIRTUAL_ENV path from
     # the 'activate' script's location in the filesystem
-    execute_process(
-        COMMAND
-            sed -i "s/^VIRTUAL_ENV=\".*\"$/VIRTUAL_ENV=\"$(cd \"$(dirname \"$(dirname \"\${BASH_SOURCE[0]}\" )\")\" \\&\\& pwd)\"/" "${VENV_PATH}/bin/activate"
-    )
+    file(READ ${VENV_PATH}/bin/activate VENV_ACTIVATE_CONTENT)
+    string(REPLACE "VIRTUAL_ENV=${VENV_PATH}" "VIRTUAL_ENV=\$(cd \$(dirname \$(dirname \${BASH_SOURCE[0]} ) ) && pwd )"
+           VENV_ACTIVATE_CONTENT "${VENV_ACTIVATE_CONTENT}")
+    file(WRITE ${VENV_PATH}/bin/activate ${VENV_ACTIVATE_CONTENT} )
 
     # Change the context of the search to only find the venv
     set( Python3_FIND_VIRTUALENV ONLY )

--- a/cmake/fckit_install_venv.cmake
+++ b/cmake/fckit_install_venv.cmake
@@ -39,30 +39,29 @@ macro( fckit_install_venv )
 
     if( Python3_VERSION VERSION_EQUAL 3.8 )
        execute_process( COMMAND ${Python3_EXECUTABLE} -m pip --disable-pip-version-check
-                        install --upgrade ${PIP_OPTIONS} pip OUTPUT_QUIET ERROR_QUIET )
+                        install --upgrade pip OUTPUT_QUIET ERROR_QUIET )
     endif()
 
 
-    # install pip dependencies
-    if( HAVE_FCKIT_VENV_OFFLINE )
-	    ecbuild_info( "Install fckit_yaml_reader dependencies in virtual environment ${VENV_PATH}" )
-        list( APPEND PIP_OPTIONS "--no-build-isolation;--no-index;--find-links=${FCKIT_VENV_WHEEL_DIR}" )
-        execute_process( COMMAND ${Python3_EXECUTABLE} -m pip --disable-pip-version-check
-                         install -r ${CMAKE_CURRENT_SOURCE_DIR}/requirements.txt
-                         ${PIP_OPTIONS} OUTPUT_QUIET )
+    unset( PIP_OPTIONS )
+    # set pip options
+    if( DEFINED ARTIFACTS_DIR )
+        list( APPEND PIP_OPTIONS "--no-index;--find-links=${ARTIFACTS_DIR}" )
+    else()
+        list( APPEND PIP_OPTIONS "--disable-pip-version-check")
     endif()
 
 
     # install virtual environment from requirements
     set( _pkg_name "fckit_yaml_reader")
     ecbuild_info( "Install fckit_yaml_reader in virtual environment ${VENV_PATH}" )
-    execute_process( COMMAND ${Python3_EXECUTABLE} -m pip --disable-pip-version-check
+    execute_process( COMMAND ${Python3_EXECUTABLE} -m pip
                      install ${PIP_OPTIONS} ${CMAKE_CURRENT_SOURCE_DIR}/src/fckit/${_pkg_name} OUTPUT_QUIET )
 
     # install fypp
     list( APPEND PIP_OPTIONS "--use-pep517" )
     ecbuild_info( "Install fypp in virtual environment ${VENV_PATH}" )
-    execute_process( COMMAND ${Python3_EXECUTABLE} -m pip --disable-pip-version-check
+    execute_process( COMMAND ${Python3_EXECUTABLE} -m pip
                      install ${PIP_OPTIONS} ${CMAKE_CURRENT_SOURCE_DIR}/contrib/fypp-3.2-b8dd58b-20230822 OUTPUT_QUIET )
 
     if( ECBUILD_INSTALL_LIBRARY_HEADERS )

--- a/populate
+++ b/populate
@@ -9,9 +9,9 @@
 # nor does it submit to any jurisdiction.
 
 if [[ $BASH_SOURCE = */* ]]; then
-    SOURCE_DIR=${BASH_SOURCE%/*}/
+    SOURCE_DIR=${BASH_SOURCE%/*}
 else
-    SOURCE_DIR=./
+    SOURCE_DIR=.
 fi
 
 ARTIFACTS_DIR=${ARTIFACTS_DIR:-"${SOURCE_DIR}/artifacts"}

--- a/populate
+++ b/populate
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+# (C) Copyright 2024- ECMWF.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+
+if [[ $BASH_SOURCE = */* ]]; then
+    SOURCE_DIR=${BASH_SOURCE%/*}/
+else
+    SOURCE_DIR=./
+fi
+
+ARTIFACTS_DIR=${ARTIFACTS_DIR:-"${SOURCE_DIR}/artifacts"}
+
+# Download dependencies for Python package in this repository
+cmake \
+    -DWHEELS_DIR=${ARTIFACTS_DIR} -DREQUIREMENT_SPEC=${SOURCE_DIR}/src/fckit/fckit_yaml_reader \
+    -DFCKIT_WHEEL_ARCH=${FCKIT_WHEEL_ARCH} -DFCKIT_WHEEL_PYTHON_VERSION=${FCKIT_WHEEL_PYTHON_VERSION} \
+    -P ${SOURCE_DIR}/cmake/fckit_download_python_wheels.cmake

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,0 @@
-ruamel.yaml==0.18.6
-ruamel.yaml.clib==0.2.12
-setuptools==75.0.0
-wheel==0.45.1

--- a/src/fckit/fckit_yaml_reader/pyproject.toml
+++ b/src/fckit/fckit_yaml_reader/pyproject.toml
@@ -1,5 +1,8 @@
 [build-system]
-requires = ["setuptools==75.0.0"]
+requires = [
+  "setuptools>=75.0.0",
+  "wheel"
+]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -7,7 +10,8 @@ name = "fckit_yaml_reader"
 version = "0.0.1"
 requires-python = ">=3.8"
 dependencies = [
-  "ruamel.yaml==0.18.6"
+  "ruamel.yaml==0.18.6",
+  "ruamel.yaml.clib==0.2.12"
 ]
 license = {text = "Apache-2.0"}
 description = "A minimal wrapper for ruamel.yaml to create an API consistent with pyyaml."

--- a/src/fckit/fckit_yaml_reader/pyproject.toml
+++ b/src/fckit/fckit_yaml_reader/pyproject.toml
@@ -11,7 +11,7 @@ version = "0.0.1"
 requires-python = ">=3.8"
 dependencies = [
   "ruamel.yaml==0.18.6",
-  "ruamel.yaml.clib==0.2.8"
+  "ruamel.yaml.clib>=0.2.8"
 ]
 license = {text = "Apache-2.0"}
 description = "A minimal wrapper for ruamel.yaml to create an API consistent with pyyaml."

--- a/src/fckit/fckit_yaml_reader/pyproject.toml
+++ b/src/fckit/fckit_yaml_reader/pyproject.toml
@@ -11,7 +11,7 @@ version = "0.0.1"
 requires-python = ">=3.8"
 dependencies = [
   "ruamel.yaml==0.18.6",
-  "ruamel.yaml.clib==0.2.12"
+  "ruamel.yaml.clib==0.2.8"
 ]
 license = {text = "Apache-2.0"}
 description = "A minimal wrapper for ruamel.yaml to create an API consistent with pyyaml."


### PR DESCRIPTION
This PR adds a populate script that can be used to cache python dependencies. The python venv installation instructions are updated accordingly as well as the README. Python version support was also improved in the process, and now 3.8 all the way up to 3.13 are supported.