### PR TITLE
Python wheel: fix fortran license copy

### DIFF
--- a/python/fckitlib/pre-compile.sh
+++ b/python/fckitlib/pre-compile.sh
@@ -26,7 +26,7 @@ if [ "$(uname)" != "Darwin" ] ; then
     patchelf --add-needed libifcoremt.so.5 /tmp/fckit/target/fckit/lib64/libifport.so.5
 
     cp /opt/intel/oneapi/compiler/latest/share/doc/compiler/licensing/fortran/LICENSE $source_target/intel.LICENSE
-    cp /opt/intel/oneapi/compiler/2025.1/share/doc/compiler/licensing/fortran/third-party-programs.txt $source_target/intel.third-party-programs.txt
+    cp /opt/intel/oneapi/compiler/latest/share/doc/compiler/licensing/fortran/third-party-programs.txt $source_target/intel.third-party-programs.txt
     echo "{\"$(echo $libs | tr ' ' ',')\": {\"home\": \"https://www.intel.com/content/www/us/en/developer/articles/license/end-user-license-agreement.html\", \"path\": \"copying/intel*\"}}" > $source_target/list.json
 
     intel_version=$(ls /opt/intel/oneapi/compiler/ | grep -v latest | sort -r | head -n 1)


### PR DESCRIPTION
Makes the wheel building more robust wrt updates of the fortran compiler in the base image

Triggered by this failure https://github.com/ecmwf/python-develop-bundle/actions/runs/16468964782/job/46553162392

(cc @pmaciel )