### PR TITLE
Re-enable editable installation of `fckit_yaml_reader`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 build
+artifacts
 install/*
 CMakeLists.txt.user
 **/*.egg-info/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -127,6 +127,11 @@ ecbuild_add_option( FEATURE FCKIT_VENV
                     DESCRIPTION "Install Python virtual environment with fypp and a yaml parser"
                     CONDITION Python3_VERSION VERSION_GREATER_EQUAL 3.8 )
 
+ecbuild_add_option( FEATURE FCKIT_VENV_EDITABLE
+                    DEFAULT OFF
+                    DESCRIPTION "Install editable packages in fckit Python virtual environment"
+                    CONDITION HAVE_FCKIT_VENV )
+
 if( HAVE_FCKIT_VENV )
    fckit_install_venv()
 else()

--- a/cmake/fckit_install_venv.cmake
+++ b/cmake/fckit_install_venv.cmake
@@ -51,6 +51,10 @@ macro( fckit_install_venv )
         list( APPEND PIP_OPTIONS "--disable-pip-version-check")
     endif()
 
+    if( HAVE_FCKIT_VENV_EDITABLE )
+        # Use checked-out source instead of installing into venv
+        list( APPEND PIP_OPTIONS "-e" )
+    endif()
 
     # install virtual environment from requirements, which includes fypp
     set( _pkg_name "fckit_yaml_reader")


### PR DESCRIPTION
A small PR that re-enables editable installations of the `fckit_yaml_reader` package.
 