### PR TITLE
Enforce minimum cmake version also in python wheel download macro

### DIFF
--- a/cmake/fckit_download_python_wheels.cmake
+++ b/cmake/fckit_download_python_wheels.cmake
@@ -50,6 +50,9 @@
 #
 ##############################################################################
 
+# We add this here to enforce the correct behaviour for find_package( Python3 ... )
+cmake_minimum_required( VERSION 3.17 FATAL_ERROR )
+
 function( download_python_wheels )
 
     set( options "" )


### PR DESCRIPTION
A small PR that raises the minimum cmake version to 3.19 and also enforces the minimum for the populate workflow. This is needed to ensure the correct python interpreter after a system update in the Atos which installed python3.12.
 