### PR TITLE
Use logical(c_bool) for interop

### DIFF
--- a/src/fckit/module/fckit_array.F90
+++ b/src/fckit/module/fckit_array.F90
@@ -9,7 +9,7 @@
 #include "fckit.h"
 
 module fckit_array_module
-use, intrinsic :: iso_c_binding, only: c_int32_t, c_int64_t, c_float, c_double
+use, intrinsic :: iso_c_binding, only: c_int32_t, c_int64_t, c_float, c_double, c_bool
 implicit none
 private
 
@@ -28,7 +28,7 @@ integer(c_int32_t), target :: zero_length_array_int32(0)
 integer(c_int64_t),target :: zero_length_array_int64(0)
 real(c_float),  target :: zero_length_array_real32(0)
 real(c_double), target :: zero_length_array_real64(0)
-logical, target :: zero_length_array_logical(0)
+logical(c_bool), target :: zero_length_array_logical(0)
 
 interface array_view1d
   module procedure array_view1d_int32_r0
@@ -152,7 +152,7 @@ end function
 
 function c_loc_logical(x)
   use, intrinsic :: iso_c_binding
-  logical, target :: x
+  logical(c_bool), target :: x
   type(c_ptr) :: c_loc_logical
   c_loc_logical = c_loc(x)
 end function
@@ -547,9 +547,9 @@ end function
 
 function array_view1d_logical_r0(scalar) result( view )
   use, intrinsic :: iso_c_binding
-  logical, intent(in), target :: scalar
+  logical(c_bool), intent(in), target :: scalar
   type(c_ptr) :: array_c_ptr
-  logical, pointer :: view(:)
+  logical(c_bool), pointer :: view(:)
   nullify(view)
   array_c_ptr = c_loc_logical(scalar)
   call c_f_pointer ( array_c_ptr , view , (/1/) )
@@ -559,9 +559,9 @@ end function
 
 function array_view1d_logical_r1(array) result( view )
   use, intrinsic :: iso_c_binding
-  logical, intent(in), target :: array(:)
+  logical(c_bool), intent(in), target :: array(:)
   type(c_ptr) :: array_c_ptr
-  logical, pointer :: view(:)
+  logical(c_bool), pointer :: view(:)
   nullify(view)
   if( size(array) > 0 ) then
     array_c_ptr = c_loc_logical(array(1))
@@ -575,9 +575,9 @@ end function
 
 function array_view1d_logical_r2(array) result( view )
   use, intrinsic :: iso_c_binding
-  logical, intent(in), target :: array(:,:)
+  logical(c_bool), intent(in), target :: array(:,:)
   type(c_ptr) :: array_c_ptr
-  logical, pointer :: view(:)
+  logical(c_bool), pointer :: view(:)
   nullify(view)
   if( size(array) > 0 ) then
     array_c_ptr = c_loc_logical(array(1,1))
@@ -591,9 +591,9 @@ end function
 
 function array_view1d_logical_r3(array) result( view )
   use, intrinsic :: iso_c_binding
-  logical, intent(in), target :: array(:,:,:)
+  logical(c_bool), intent(in), target :: array(:,:,:)
   type(c_ptr) :: array_c_ptr
-  logical, pointer :: view(:)
+  logical(c_bool), pointer :: view(:)
   nullify(view)
   if( size(array) > 0 ) then
     array_c_ptr = c_loc_logical(array(1,1,1))
@@ -607,9 +607,9 @@ end function
 
 function array_view1d_logical_r4(array) result( view )
   use, intrinsic :: iso_c_binding
-  logical, intent(in), target :: array(:,:,:,:)
+  logical(c_bool), intent(in), target :: array(:,:,:,:)
   type(c_ptr) :: array_c_ptr
-  logical, pointer :: view(:)
+  logical(c_bool), pointer :: view(:)
   nullify(view)
   if( size(array) > 0 ) then
     array_c_ptr = c_loc_logical(array(1,1,1,1))
@@ -623,7 +623,7 @@ end function
 
 function array_view1d_logical_r0_mold_int32(scalar,mold) result( view )
   use, intrinsic :: iso_c_binding
-  logical, intent(in)  :: scalar
+  logical(c_bool), intent(in)  :: scalar
   integer(c_int32_t), intent(in) :: mold
   type(c_ptr) :: array_c_ptr
   integer(c_int32_t), pointer :: view(:)
@@ -637,7 +637,7 @@ end function
 
 function array_view1d_logical_r1_mold_int32(array,mold) result( view )
   use, intrinsic :: iso_c_binding
-  logical, intent(in), target :: array(:)
+  logical(c_bool), intent(in), target :: array(:)
   integer(c_int32_t), intent(in) :: mold
   type(c_ptr) :: array_c_ptr
   integer(c_int32_t), pointer :: view(:)
@@ -655,7 +655,7 @@ end function
 
 function array_view1d_logical_r2_mold_int32(array,mold) result( view )
   use, intrinsic :: iso_c_binding
-  logical, intent(in), target :: array(:,:)
+  logical(c_bool), intent(in), target :: array(:,:)
   integer(c_int32_t), intent(in) :: mold
   type(c_ptr) :: array_c_ptr
   integer(c_int32_t), pointer :: view(:)
@@ -673,7 +673,7 @@ end function
 
 function array_view1d_logical_r3_mold_int32(array,mold) result( view )
   use, intrinsic :: iso_c_binding
-  logical, intent(in), target :: array(:,:,:)
+  logical(c_bool), intent(in), target :: array(:,:,:)
   integer(c_int32_t), intent(in) :: mold
   type(c_ptr) :: array_c_ptr
   integer(c_int32_t), pointer :: view(:)
@@ -691,7 +691,7 @@ end function
 
 function array_view1d_logical_r4_mold_int32(array,mold) result( view )
   use, intrinsic :: iso_c_binding
-  logical, intent(in), target :: array(:,:,:,:)
+  logical(c_bool), intent(in), target :: array(:,:,:,:)
   integer(c_int32_t), intent(in) :: mold
   type(c_ptr) :: array_c_ptr
   integer(c_int32_t), pointer :: view(:)

--- a/src/fckit/module/fckit_mpi.fypp
+++ b/src/fckit/module/fckit_mpi.fypp
@@ -18,7 +18,7 @@
 #:set ranks  = [0,1,2,3,4]
 #:set dim    = ['','(:)','(:,:)','(:,:,:)','(:,:,:,:)','(:,:,:,:,:)']
 
-#:set ftypes = ['integer(c_int32_t)','integer(c_int64_t)','real(c_float)','real(c_double)','logical']
+#:set ftypes = ['integer(c_int32_t)','integer(c_int64_t)','real(c_float)','real(c_double)','logical(c_bool)']
 #:set btypes = ['integer(c_int32_t)','integer(c_int64_t)','real(c_float)','real(c_double)','integer(c_int32_t)']
 #:set dtypes = ['int32', 'int64', 'real32', 'real64','logical']
 

--- a/src/tests/test_fypp.fypp
+++ b/src/tests/test_fypp.fypp
@@ -1,7 +1,7 @@
 #:mute
 #:set ranks  = [1,2,3,4,5]
 #:set dim    = ['',':',':,:',':,:,:',':,:,:,:',':,:,:,:,:']
-#:set ftypes = ['integer(c_int)','integer(c_long)','real(c_float)','real(c_double)', 'logical']
+#:set ftypes = ['integer(c_int)','integer(c_long)','real(c_float)','real(c_double)', 'logical(c_bool)']
 #:set dtypes = ['int32', 'int64', 'real32', 'real64', 'logical32']
 #:set types  = list(zip(dtypes,ftypes))
 

--- a/src/tests/test_mpi.F90
+++ b/src/tests/test_mpi.F90
@@ -423,7 +423,7 @@ TEST( test_broadcast )
   real(c_float)   :: real32, real32_r2(3,2)
   integer(c_int32_t) :: int32,  int32_r3(4,3,2)
   integer(c_long) :: int64,  int64_r4(4,3,2,2)
-  logical :: logical_r1(4)
+  logical(c_bool) :: logical_r1(4)
   character(len=30) :: string_r0
 
   FCKIT_SUPPRESS_UNUSED( real64_r1 )
@@ -458,7 +458,7 @@ TEST( test_broadcast )
 
   if(comm%rank()==comm%size()-1) logical_r1(2) = .true.
   call comm%broadcast(logical_r1,root=comm%size()-1)
-  FCTEST_CHECK_EQUAL(logical_r1(2), .true.)
+  FCTEST_CHECK_EQUAL(logical(logical_r1(2)), .true.)
 
   if(comm%rank()==comm%size()-1) string_r0 = "path/filename"
   call comm%broadcast(string_r0,root=comm%size()-1)


### PR DESCRIPTION
### Description

Addresses https://github.com/ecmwf/atlas/issues/333 in conjunction with https://github.com/ecmwf/atlas/pull/334.  Changes logical to logical(c_bool) where C interop is concerned.

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 