### PR TITLE
Add optional output suffix to `fckit_target_preprocess_fypp`

### DIFF
--- a/cmake/fckit_preprocess_fypp.cmake
+++ b/cmake/fckit_preprocess_fypp.cmake
@@ -52,7 +52,8 @@ endfunction()
 #                                [SOURCES file1 [file2]... ]
 #                                [FYPP_ARGS arg1 [arg2]... ]
 #                                [FYPP_ARGS_EXCLUDE arg1 [arg2]... ]
-#                                [DEPENDS dep1 [dep2]... ] )
+#                                [DEPENDS dep1 [dep2]... ]
+#                                [OUTPUT_SUFFIX suffix] )
 #    Purpose:
 #        Preprocess source files with fypp
 #
@@ -62,6 +63,7 @@ endfunction()
 #        [FYPP_ARGS arg1 [arg2]...]          Arguments passed to fypp
 #        [FYPP_ARGS_EXCLUDE arg1 [arg2]...]  Arguments excluded from being passed to fypp; accepts bash-compatible regex
 #        [DEPENDS dep1 [dep2]... ]           Dependencies before processing files
+#        [OUTPUT_SUFFIX suffix]              Optional suffix appended to generated basenames before .F90
 #
 #    Notes:
 #        The include flags and compile flags of targets with the DEPENDS argument
@@ -70,7 +72,7 @@ endfunction()
 function( fckit_preprocess_fypp_sources output )
 
   set( options NO_LINE_NUMBERING )
-  set( single_value_args "" )
+  set( single_value_args OUTPUT_SUFFIX )
   set( multi_value_args SOURCES FYPP_ARGS FYPP_ARGS_EXCLUDE DEPENDS )
   cmake_parse_arguments( _PAR "${options}" "${single_value_args}" "${multi_value_args}"  ${_FIRST_ARG} ${ARGN} )
 
@@ -89,7 +91,7 @@ function( fckit_preprocess_fypp_sources output )
     if( dir )
       set( outfile "${outfile}/${dir}" )
     endif()
-    set( outfile "${outfile}/${base}.F90" )
+    set( outfile "${outfile}/${base}${_PAR_OUTPUT_SUFFIX}.F90" )
 
     list( APPEND outfiles ${outfile} )
 
@@ -125,9 +127,9 @@ function( fckit_preprocess_fypp_sources output )
     endforeach()
 
     if( dir )
-      set( short_outfile "${dir}/${base}.F90" )
+      set( short_outfile "${dir}/${base}${_PAR_OUTPUT_SUFFIX}.F90" )
     else()
-      set( short_outfile "${base}.F90")
+      set( short_outfile "${base}${_PAR_OUTPUT_SUFFIX}.F90")
     endif()
 
     get_source_file_property( _depends ${filename} OBJECT_DEPENDS )
@@ -173,7 +175,8 @@ endfunction()
 # fckit_target_preprocess_fypp( target
 #                               [FYPP_ARGS arg1 [arg2]... ]
 #                               [FYPP_ARGS_EXCLUDE arg1 [arg2]... ]
-#                               [DEPENDS dep1 [dep2]... ] )
+#                               [DEPENDS dep1 [dep2]... ]
+#                               [OUTPUT_SUFFIX suffix] )
 #    Purpose:
 #        Preprocess source files in the target with the extensions
 #        {.fypp, .fypp.F90, .F90.fypp}
@@ -183,6 +186,7 @@ endfunction()
 #        [FYPP_ARGS arg1 [arg2]...]           Arguments passed to fypp
 #        [FYPP_ARGS_EXCLUDE arg1 [arg2]... ]  Arguments excluded from being passed to fypp; accepts bash-compatible regex
 #        [DEPENDS dep1 [dep2]... ]            Dependencies before processing files
+#        [OUTPUT_SUFFIX suffix]               Optional suffix appended to generated basenames before .F90
 #
 #    Notes:
 #        The include flags and compile flags of current target and targets
@@ -192,7 +196,7 @@ endfunction()
 function( fckit_target_preprocess_fypp _PAR_TARGET )
 
   set( options NO_LINE_NUMBERING )
-  set( single_value_args "" )
+  set( single_value_args OUTPUT_SUFFIX )
   set( multi_value_args FYPP_ARGS FYPP_ARGS_EXCLUDE DEPENDS )
   cmake_parse_arguments( _PAR "${options}" "${single_value_args}" "${multi_value_args}"  ${_FIRST_ARG} ${ARGN} )
 
@@ -252,6 +256,7 @@ function( fckit_target_preprocess_fypp _PAR_TARGET )
           FYPP_ARGS ${_PAR_FYPP_ARGS} ${args}
           FYPP_ARGS_EXCLUDE ${_PAR_FYPP_ARGS_EXCLUDE}
           DEPENDS ${preprocessed_depends} ${_PAR_DEPENDS}
+          OUTPUT_SUFFIX ${_PAR_OUTPUT_SUFFIX}
       )
 
       target_sources( ${_PAR_TARGET} PRIVATE ${preprocessed_sources} )

--- a/src/tests/test_downstream_fypp/downstream/CMakeLists.txt
+++ b/src/tests/test_downstream_fypp/downstream/CMakeLists.txt
@@ -12,6 +12,12 @@ ecbuild_add_library(
     SOURCES downstream.fypp downstream_override.fypp
     PUBLIC_LIBS fckit
     DEFINITIONS _POSIX_C_SOURCE=200809L exclude_from_fypp)
-fckit_target_preprocess_fypp( downstream FYPP_ARGS_EXCLUDE "exclude_from_fypp" )
+
+set( _fypp_args FYPP_ARGS_EXCLUDE "exclude_from_fypp" )
+if( DEFINED DOWNSTREAM_FYPP_OUTPUT_SUFFIX )
+  list( APPEND _fypp_args OUTPUT_SUFFIX "${DOWNSTREAM_FYPP_OUTPUT_SUFFIX}" )
+endif()
+
+fckit_target_preprocess_fypp( downstream ${_fypp_args} )
 
 ecbuild_add_executable( TARGET main SOURCES main.F90 LIBS fckit downstream )

--- a/src/tests/test_downstream_fypp/test-downstream.sh.in
+++ b/src/tests/test_downstream_fypp/test-downstream.sh.in
@@ -8,7 +8,7 @@
 #   test-individual.sh [CMAKE_ARGUMENTS]
 
 SOURCE=@CMAKE_CURRENT_SOURCE_DIR@/downstream
-BUILD=@CMAKE_CURRENT_BINARY_DIR@/downstream
+BUILD_ROOT=@CMAKE_CURRENT_BINARY_DIR@
 
 # Error handling
 function test_failed {
@@ -25,23 +25,48 @@ trap test_failed EXIT
 set -e -o pipefail
 set -x
 
-# Start with clean build
-rm -rf $BUILD
-
 export fckit_DIR=@PROJECT_BINARY_DIR@
 export ecbuild_DIR=@ecbuild_DIR@
 
-# Build
-mkdir -p $BUILD && cd $BUILD
-cmake $SOURCE \
-  -DCMAKE_BUILD_TYPE=RelWithDebInfo \
-  -DECBUILD_2_COMPAT=OFF \
-  -DECBUILD_COMPILE_FLAGS=@CMAKE_CURRENT_SOURCE_DIR@/compile_flags.cmake \
+COMMON_CMAKE_ARGS=(
+  -DCMAKE_BUILD_TYPE=RelWithDebInfo
+  -DECBUILD_2_COMPAT=OFF
+  -DECBUILD_COMPILE_FLAGS=@CMAKE_CURRENT_SOURCE_DIR@/compile_flags.cmake
   "$@"
+)
 
-make VERBOSE=1
+function build_and_check {
+  local variant=$1
+  local output_suffix=$2
+  local build_dir=${BUILD_ROOT}/downstream_${variant}
 
-bin/main
+  rm -rf "$build_dir"
+  mkdir -p "$build_dir"
+  cd "$build_dir"
+
+  local cmake_args=("${COMMON_CMAKE_ARGS[@]}")
+  if [ -n "$output_suffix" ]; then
+    cmake_args+=("-DDOWNSTREAM_FYPP_OUTPUT_SUFFIX=${output_suffix}")
+  fi
+
+  cmake "$SOURCE" "${cmake_args[@]}"
+  make VERBOSE=1
+
+  if [ -n "$output_suffix" ]; then
+    test -f "downstream${output_suffix}.F90"
+    test -f "downstream_override${output_suffix}.F90"
+    test ! -e "downstream.F90"
+    test ! -e "downstream_override.F90"
+  else
+    test -f "downstream.F90"
+    test -f "downstream_override.F90"
+  fi
+
+  bin/main
+}
+
+build_and_check default ""
+build_and_check suffixed "_custom"
 
 { set +ex; } 2>/dev/null
 echo "+++++++++++++++++"


### PR DESCRIPTION
This PR contributes an optional `OUTPUT_SUFFIX` to the `fckit_target_preprocess_fypp` macro, typically to be used when building multiple precision variants of the same target.