### PR TITLE
Feature/remove compiler workarounds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,17 +28,6 @@ ecbuild_enable_fortran( REQUIRED MODULE_DIRECTORY ${PROJECT_BINARY_DIR}/module )
 ecbuild_check_fortran( FEATURES finalization )
 
 set( FEATURE_FINAL_DEFAULT ON )
-set( PGIBUG_ATLAS_197 0 )
-if( CMAKE_Fortran_COMPILER_ID MATCHES "PGI|NVHPC" )
-  if( ${CMAKE_Fortran_COMPILER_VERSION} VERSION_LESS 19.4 )
-      set( PGIBUG_ATLAS_197 1 )
-  endif()
-  if( ${CMAKE_Fortran_COMPILER_VERSION} VERSION_LESS 19.10 )
-    # Compilation works, but runtime segmentation faults occur (tested with pgi/17.7)
-    set( FEATURE_FINAL_DEFAULT OFF )
-  endif()
-endif()
-
 
 ecbuild_add_option( FEATURE FINAL
                     DESCRIPTION "Enable automatic finalisation for derived types (destructors)"

--- a/src/fckit/fckit.h.in
+++ b/src/fckit/fckit.h.in
@@ -40,24 +40,8 @@ does it submit to any jurisdiction.
 associate( unused_ => X ); \
 end associate
 
-#define PGIBUG_ATLAS_197 @PGIBUG_ATLAS_197@
-#if 0
-Following is to workaround PGI bug which prevents the use of function c_ptr()
-PGI bug present from version 17.10, fixed since version 19.4
-#endif
-#if PGIBUG_ATLAS_197
-#define CPTR_PGIBUG_A cpp_object_ptr
-#define CPTR_PGIBUG_B shared_object_%cpp_object_ptr
-#else
 #define CPTR_PGIBUG_A c_ptr()
 #define CPTR_PGIBUG_B c_ptr()
-#endif
-
-#define PGIBUG_ATLAS_197_DEBUG 0
-#if 0
-When above PGIBUG_ATLAS_197_DEBUG==1 then the c_ptr() member functions are disabled from compilation,
-to detect possible dangerous use cases when the PGI bug ATLAS-197 is present.
-#endif
 
 #define XLBUG_FCKIT_14 1
 #if 0

--- a/src/fckit/fckit.h.in
+++ b/src/fckit/fckit.h.in
@@ -40,19 +40,13 @@ does it submit to any jurisdiction.
 associate( unused_ => X ); \
 end associate
 
+#if 0
+Following 2 macros were for a workaround PGI bug (PGI_BUG_ATLAS_197) which prevents the use of function c_ptr()
+PGI bug present from version 17.10, fixed since version 19.4
+The definitions are only remaining for downstream code that may still reference these.
+#endif
 #define CPTR_PGIBUG_A c_ptr()
 #define CPTR_PGIBUG_B c_ptr()
-
-#define XLBUG_FCKIT_14 1
-#if 0
-Following is to workaround XL bug where allocate( character(len=xxx,kind=c_char ) :: string )
-does not compile
-#endif
-#if XLBUG_FCKIT_14
-#define FCKIT_ALLOCATE_CHARACTER( VARIABLE, SIZE ) allocate( character(len=(SIZE)) :: VARIABLE )
-#else
-#define FCKIT_ALLOCATE_CHARACTER( VARIABLE, SIZE ) allocate( character(len=(SIZE),kind=c_char) :: VARIABLE )
-#endif
 
 #if 0
 // clang-format on

--- a/src/fckit/module/fckit_C_interop.F90
+++ b/src/fckit/module/fckit_C_interop.F90
@@ -151,7 +151,7 @@ function c_str_to_string(s) result(string)
      i = i + 1
   enddo
   nchars = i - 1  ! Exclude null character from Fortran string
-  FCKIT_ALLOCATE_CHARACTER(string,nchars)
+  allocate( character(len=(nchars),kind=c_char) :: string )
   do i=1,nchars
     string(i:i) = s(i)
   enddo
@@ -168,7 +168,7 @@ subroutine copy_c_str_to_string(s,string)
      if (s(i) == c_null_char) exit
   enddo
   nchars = i - 1  ! Exclude null character from Fortran string
-  FCKIT_ALLOCATE_CHARACTER(string,nchars)
+  allocate( character(len=(nchars),kind=c_char) :: string )
   do i=1,nchars
     string(i:i) = s(i)
   enddo

--- a/src/fckit/module/fckit_buffer.F90
+++ b/src/fckit/module/fckit_buffer.F90
@@ -102,7 +102,7 @@ function str(this)
   integer(c_size_t) :: str_size
   type(c_ptr) :: str_cptr
   errcode = c_fckit_buffer_str(this%c_ptr(),str_cptr,str_size)
-  FCKIT_ALLOCATE_CHARACTER(str,str_size)
+  allocate( character(len=(str_size),kind=c_char) :: str )
   str = c_ptr_to_string(str_cptr)
   call c_ptr_free(str_cptr)
 end function

--- a/src/fckit/module/fckit_buffer.F90
+++ b/src/fckit/module/fckit_buffer.F90
@@ -101,7 +101,7 @@ function str(this)
   integer(c_int32_t) :: errcode
   integer(c_size_t) :: str_size
   type(c_ptr) :: str_cptr
-  errcode = c_fckit_buffer_str(this%CPTR_PGIBUG_B,str_cptr,str_size)
+  errcode = c_fckit_buffer_str(this%c_ptr(),str_cptr,str_size)
   FCKIT_ALLOCATE_CHARACTER(str,str_size)
   str = c_ptr_to_string(str_cptr)
   call c_ptr_free(str_cptr)

--- a/src/fckit/module/fckit_configuration.F90
+++ b/src/fckit/module/fckit_configuration.F90
@@ -440,7 +440,7 @@ function key(this, index) result(key_str)
   type(c_ptr) :: key_cptr
   integer(c_size_t) :: key_size
   call c_fckit_configuration_key(this%c_ptr(), index, key_cptr, key_size)
-  FCKIT_ALLOCATE_CHARACTER(key_str, key_size)
+  allocate( character(len=(key_size),kind=c_char) :: key_str )
   key_str = c_ptr_to_string(key_cptr)
   call c_ptr_free(key_cptr)
 end function
@@ -759,7 +759,7 @@ function get_string(this, name, value) result(found)
   found_int = c_fckit_configuration_get_string(this%c_ptr(),c_str(name),value_cptr,value_size)
   if( found_int == 1 ) then
     if( allocated(value) ) deallocate(value)
-    FCKIT_ALLOCATE_CHARACTER(value,value_size)
+    allocate( character(len=(value_size),kind=c_char) :: value )
     if ( value_size > 0 ) then
       value = c_ptr_to_string(value_cptr)
       call c_ptr_free(value_cptr)
@@ -1011,7 +1011,7 @@ function json(this) result(jsonstr)
   type(c_ptr) :: json_cptr
   integer(c_size_t) :: json_size
   call c_fckit_configuration_json(this%c_ptr(),json_cptr,json_size)
-  FCKIT_ALLOCATE_CHARACTER(jsonstr,json_size)
+  allocate( character(len=(json_size),kind=c_char) :: jsonstr )
   jsonstr = c_ptr_to_string(json_cptr)
   call c_ptr_free(json_cptr)
 end function

--- a/src/fckit/module/fckit_configuration.F90
+++ b/src/fckit/module/fckit_configuration.F90
@@ -404,7 +404,7 @@ function ctor_from_buffer(buffer) result(this)
   use fckit_c_interop_module, only : c_str
   type(fckit_Configuration) :: this
   type(fckit_buffer), intent(in) :: buffer
-  call this%reset_c_ptr( c_fckit_configuration_new_from_buffer(buffer%CPTR_PGIBUG_B), &
+  call this%reset_c_ptr( c_fckit_configuration_new_from_buffer(buffer%c_ptr()), &
     & fckit_c_deleter(c_fckit_configuration_delete) )
   call buffer%consumed() ! If buffer was constructed inline, this will delete the buffer
   call this%return()
@@ -414,7 +414,7 @@ function fckit_configuration_size(this) result(val)
   use fckit_c_interop_module, only : c_str
   class(fckit_Configuration), intent(in) :: this
   integer(c_int32_t) :: val
-  val =  c_fckit_configuration_size(this%CPTR_PGIBUG_B)
+  val =  c_fckit_configuration_size(this%c_ptr())
   write(0,*) "fckit_configuration_size " , val
 end function
 
@@ -424,7 +424,7 @@ function has(this, name) result(value)
   character(kind=c_char,len=*), intent(in) :: name
   logical :: value
   integer(c_int32_t) :: value_int
-  value_int =  c_fckit_configuration_has(this%CPTR_PGIBUG_B, c_str(name) )
+  value_int =  c_fckit_configuration_has(this%c_ptr(), c_str(name) )
   if( value_int == 1 ) then
     value = .True.
   else
@@ -439,7 +439,7 @@ function key(this, index) result(key_str)
   integer(c_int32_t), intent(in) :: index
   type(c_ptr) :: key_cptr
   integer(c_size_t) :: key_size
-  call c_fckit_configuration_key(this%CPTR_PGIBUG_B, index, key_cptr, key_size)
+  call c_fckit_configuration_key(this%c_ptr(), index, key_cptr, key_size)
   FCKIT_ALLOCATE_CHARACTER(key_str, key_size)
   key_str = c_ptr_to_string(key_cptr)
   call c_ptr_free(key_cptr)
@@ -450,7 +450,7 @@ function get_size(this, name) result(val)
   class(fckit_Configuration), intent(in) :: this
   character(kind=c_char,len=*), intent(in) :: name
   integer(c_int32_t) :: val
-  val = c_fckit_configuration_get_size(this%CPTR_PGIBUG_B, c_str(name) )
+  val = c_fckit_configuration_get_size(this%c_ptr(), c_str(name) )
 end function
 
 subroutine set_config(this, name, value)
@@ -458,7 +458,7 @@ subroutine set_config(this, name, value)
   class(fckit_Configuration), intent(inout) :: this
   character(kind=c_char,len=*), intent(in) :: name
   class(fckit_Configuration), intent(in) :: value
-  call c_fckit_configuration_set_config(this%CPTR_PGIBUG_B, c_str(name), value%CPTR_PGIBUG_B )
+  call c_fckit_configuration_set_config(this%c_ptr(), c_str(name), value%c_ptr() )
 end subroutine
 
 subroutine set_config_list(this, name, value)
@@ -471,9 +471,9 @@ subroutine set_config_list(this, name, value)
   integer(c_int32_t) :: j
   if( size(value) > 0 ) then
     do j=1,size(value)
-      value_cptrs(j) = value(j)%CPTR_PGIBUG_B
+      value_cptrs(j) = value(j)%c_ptr()
     enddo
-    call c_fckit_configuration_set_config_list(this%CPTR_PGIBUG_B, c_str(name),  &
+    call c_fckit_configuration_set_config_list(this%c_ptr(), c_str(name),  &
       c_loc(value_cptrs(1)), size(value_cptrs,kind=c_size_t) )
   endif
 end subroutine
@@ -490,7 +490,7 @@ subroutine set_logical(this, name, value)
   else
     value_int = 0
   end if
-  call c_fckit_configuration_set_bool(this%CPTR_PGIBUG_B, c_str(name), value_int )
+  call c_fckit_configuration_set_bool(this%c_ptr(), c_str(name), value_int )
 end subroutine
 
 subroutine set_int32(this, name, value)
@@ -498,7 +498,7 @@ subroutine set_int32(this, name, value)
   class(fckit_Configuration), intent(inout) :: this
   character(kind=c_char,len=*), intent(in) :: name
   integer(c_int32_t), intent(in) :: value
-  call c_fckit_configuration_set_int32(this%CPTR_PGIBUG_B, c_str(name), value)
+  call c_fckit_configuration_set_int32(this%c_ptr(), c_str(name), value)
 end subroutine
 
 subroutine set_int64(this, name, value)
@@ -506,7 +506,7 @@ subroutine set_int64(this, name, value)
   class(fckit_Configuration), intent(inout) :: this
   character(kind=c_char,len=*), intent(in) :: name
   integer(c_int64_t), intent(in) :: value
-  call c_fckit_configuration_set_int64(this%CPTR_PGIBUG_B, c_str(name), value)
+  call c_fckit_configuration_set_int64(this%c_ptr(), c_str(name), value)
 end subroutine
 
 subroutine set_real32(this, name, value)
@@ -514,7 +514,7 @@ subroutine set_real32(this, name, value)
   class(fckit_Configuration), intent(inout) :: this
   character(kind=c_char,len=*), intent(in) :: name
   real(c_float), intent(in) :: value
-  call c_fckit_configuration_set_float(this%CPTR_PGIBUG_B, c_str(name) ,value)
+  call c_fckit_configuration_set_float(this%c_ptr(), c_str(name) ,value)
 end subroutine
 
 subroutine set_real64(this, name, value)
@@ -522,7 +522,7 @@ subroutine set_real64(this, name, value)
   class(fckit_Configuration), intent(inout) :: this
   character(kind=c_char,len=*), intent(in) :: name
   real(c_double), intent(in) :: value
-  call c_fckit_configuration_set_double(this%CPTR_PGIBUG_B, c_str(name) ,value)
+  call c_fckit_configuration_set_double(this%c_ptr(), c_str(name) ,value)
 end subroutine
 
 subroutine set_string(this, name, value)
@@ -530,7 +530,7 @@ subroutine set_string(this, name, value)
   class(fckit_Configuration), intent(inout) :: this
   character(kind=c_char,len=*), intent(in) :: name
   character(kind=c_char,len=*), intent(in) :: value
-  call c_fckit_configuration_set_string(this%CPTR_PGIBUG_B, c_str(name) , c_str(value) )
+  call c_fckit_configuration_set_string(this%c_ptr(), c_str(name) , c_str(value) )
 end subroutine
 
 subroutine set_array_string(this, name, value)
@@ -549,7 +549,7 @@ subroutine set_array_string(this, name, value)
     do ii = 1, size(value)
       flatvalue((ii-1)*length+1:ii*length) = value(ii)
     enddo
-    call c_fckit_configuration_set_array_string(this%CPTR_PGIBUG_B, c_str(name), &
+    call c_fckit_configuration_set_array_string(this%c_ptr(), c_str(name), &
       &  c_str(flatvalue), length, size(value,kind=c_size_t) )
   endif
 end subroutine
@@ -559,7 +559,7 @@ subroutine set_array_int32(this, name, value)
   class(fckit_Configuration), intent(in) :: this
   character(kind=c_char,len=*), intent(in) :: name
   integer(c_int32_t), intent(in) :: value(:)
-  call c_fckit_configuration_set_array_int32(this%CPTR_PGIBUG_B, c_str(name), value, size(value,kind=c_size_t) )
+  call c_fckit_configuration_set_array_int32(this%c_ptr(), c_str(name), value, size(value,kind=c_size_t) )
 end subroutine
 
 subroutine set_array_int64(this, name, value)
@@ -567,7 +567,7 @@ subroutine set_array_int64(this, name, value)
   class(fckit_Configuration), intent(in) :: this
   character(kind=c_char,len=*), intent(in) :: name
   integer(c_int64_t), intent(in) :: value(:)
-  call c_fckit_configuration_set_array_int64(this%CPTR_PGIBUG_B, c_str(name), value, size(value,kind=c_size_t) )
+  call c_fckit_configuration_set_array_int64(this%c_ptr(), c_str(name), value, size(value,kind=c_size_t) )
 end subroutine
 
 subroutine set_array_real32(this, name, value)
@@ -575,7 +575,7 @@ subroutine set_array_real32(this, name, value)
   class(fckit_Configuration), intent(in) :: this
   character(kind=c_char,len=*), intent(in) :: name
   real(c_float), intent(in) :: value(:)
-  call c_fckit_configuration_set_array_float(this%CPTR_PGIBUG_B, c_str(name), value, size(value,kind=c_size_t) )
+  call c_fckit_configuration_set_array_float(this%c_ptr(), c_str(name), value, size(value,kind=c_size_t) )
 end subroutine
 
 subroutine set_array_real64(this, name, value)
@@ -583,7 +583,7 @@ subroutine set_array_real64(this, name, value)
   class(fckit_Configuration), intent(in) :: this
   character(kind=c_char,len=*), intent(in) :: name
   real(c_double), intent(in) :: value(:)
-  call c_fckit_configuration_set_array_double(this%CPTR_PGIBUG_B, c_str(name), value, size(value,kind=c_size_t) )
+  call c_fckit_configuration_set_array_double(this%c_ptr(), c_str(name), value, size(value,kind=c_size_t) )
 end subroutine
 
 function get_config(this, name, value) result(found)
@@ -594,8 +594,8 @@ function get_config(this, name, value) result(found)
   class(fckit_Configuration), intent(inout) :: value
   integer(c_int32_t) :: found_int
   value = fckit_Configuration()
-  found_int = c_fckit_configuration_get_config(this%CPTR_PGIBUG_B, &
-    c_str(name), value%CPTR_PGIBUG_B )
+  found_int = c_fckit_configuration_get_config(this%c_ptr(), &
+    c_str(name), value%c_ptr() )
   found = .False.
   if (found_int == 1) then
     found = .True.
@@ -623,7 +623,7 @@ function get_config_list(this, name, value) result(found)
   integer(c_size_t) :: j
   call deallocate_fckit_configuration(value)
   value_list_cptr = c_null_ptr
-  found_int = c_fckit_configuration_get_config_list(this%CPTR_PGIBUG_B, c_str(name), &
+  found_int = c_fckit_configuration_get_config_list(this%c_ptr(), c_str(name), &
     & value_list_cptr, value_list_size)
   found = .False.
   if( found_int == 1 ) then
@@ -652,7 +652,7 @@ function get_logical(this, name, value) result(found)
   logical, intent(inout) :: value
   integer(c_int32_t) :: value_int
   integer(c_int32_t) :: found_int
-  found_int = c_fckit_configuration_get_bool(this%CPTR_PGIBUG_B,c_str(name), value_int )
+  found_int = c_fckit_configuration_get_bool(this%c_ptr(),c_str(name), value_int )
   found = .False.
   if (found_int == 1) found = .True.
   if (found) then
@@ -678,7 +678,7 @@ function get_int32(this, name, value) result(found)
   character(kind=c_char,len=*), intent(in) :: name
   integer(c_int32_t), intent(inout) :: value
   integer(c_int32_t) :: found_int
-  found_int = c_fckit_configuration_get_int32(this%CPTR_PGIBUG_B, c_str(name), value )
+  found_int = c_fckit_configuration_get_int32(this%c_ptr(), c_str(name), value )
   found = .False.
   if (found_int == 1) found = .True.
 end function
@@ -697,7 +697,7 @@ function get_int64(this, name, value) result(found)
   character(kind=c_char,len=*), intent(in) :: name
   integer(c_int64_t), intent(inout) :: value
   integer(c_int32_t) :: found_int
-  found_int = c_fckit_configuration_get_int64(this%CPTR_PGIBUG_B, c_str(name), value )
+  found_int = c_fckit_configuration_get_int64(this%c_ptr(), c_str(name), value )
   found = .False.
   if (found_int == 1) found = .True.
 end function
@@ -716,7 +716,7 @@ function get_real32(this, name, value) result(found)
   character(kind=c_char,len=*), intent(in) :: name
   real(c_float), intent(inout) :: value
   integer(c_int32_t) :: found_int
-  found_int = c_fckit_configuration_get_float(this%CPTR_PGIBUG_B, c_str(name), value )
+  found_int = c_fckit_configuration_get_float(this%c_ptr(), c_str(name), value )
   found = .False.
   if (found_int == 1) found = .True.
 end function
@@ -735,7 +735,7 @@ function get_real64(this, name, value) result(found)
   character(kind=c_char,len=*), intent(in) :: name
   real(c_double), intent(inout) :: value
   integer(c_int32_t) :: found_int
-  found_int = c_fckit_configuration_get_double(this%CPTR_PGIBUG_B, c_str(name), value )
+  found_int = c_fckit_configuration_get_double(this%c_ptr(), c_str(name), value )
   found = .False.
   if (found_int == 1) found = .True.
 end function
@@ -756,7 +756,7 @@ function get_string(this, name, value) result(found)
   type(c_ptr) :: value_cptr
   integer(c_int32_t) :: found_int
   integer(c_size_t) :: value_size
-  found_int = c_fckit_configuration_get_string(this%CPTR_PGIBUG_B,c_str(name),value_cptr,value_size)
+  found_int = c_fckit_configuration_get_string(this%c_ptr(),c_str(name),value_cptr,value_size)
   if( found_int == 1 ) then
     if( allocated(value) ) deallocate(value)
     FCKIT_ALLOCATE_CHARACTER(value,value_size)
@@ -788,7 +788,7 @@ function get_array_logical(this, name, value) result(found)
   integer(c_size_t) :: j, value_size
   integer(c_int32_t), allocatable :: value_int(:)
   integer(c_int32_t) :: found_int
-  found_int = c_fckit_configuration_get_array_int32(this%CPTR_PGIBUG_B, c_str(name), &
+  found_int = c_fckit_configuration_get_array_int32(this%c_ptr(), c_str(name), &
    & value_cptr, value_size )
   if( found_int == 1 ) then
     call c_f_pointer(value_cptr,value_fptr,(/value_size/))
@@ -827,7 +827,7 @@ function get_array_int32(this, name, value) result(found)
   integer(c_int32_t), pointer :: value_fptr(:)
   integer(c_size_t) :: value_size
   integer(c_int32_t) :: found_int
-  found_int = c_fckit_configuration_get_array_int32(this%CPTR_PGIBUG_B, c_str(name), &
+  found_int = c_fckit_configuration_get_array_int32(this%c_ptr(), c_str(name), &
    & value_cptr, value_size )
   if( found_int == 1 ) then
     call c_f_pointer(value_cptr,value_fptr,(/value_size/))
@@ -858,7 +858,7 @@ function get_array_int64(this, name, value) result(found)
   integer(c_int64_t), pointer :: value_fptr(:)
   integer(c_size_t) :: value_size
   integer(c_int32_t) :: found_int
-  found_int = c_fckit_configuration_get_array_int64(this%CPTR_PGIBUG_B, c_str(name), &
+  found_int = c_fckit_configuration_get_array_int64(this%c_ptr(), c_str(name), &
    & value_cptr, value_size )
   if( found_int == 1 ) then
     call c_f_pointer(value_cptr,value_fptr,(/value_size/))
@@ -889,7 +889,7 @@ function get_array_real32(this, name, value) result(found)
   real(c_float), pointer :: value_fptr(:)
   integer(c_size_t) :: value_size
   integer(c_int32_t) :: found_int
-  found_int = c_fckit_configuration_get_array_float(this%CPTR_PGIBUG_B, c_str(name), &
+  found_int = c_fckit_configuration_get_array_float(this%c_ptr(), c_str(name), &
    & value_cptr, value_size )
   if( found_int == 1 ) then
     call c_f_pointer(value_cptr,value_fptr,(/value_size/))
@@ -920,7 +920,7 @@ function get_array_real64(this, name, value) result(found)
   real(c_double), pointer :: value_fptr(:)
   integer(c_size_t) :: value_size
   integer(c_int32_t) :: found_int
-  found_int = c_fckit_configuration_get_array_double(this%CPTR_PGIBUG_B, c_str(name), &
+  found_int = c_fckit_configuration_get_array_double(this%c_ptr(), c_str(name), &
    & value_cptr, value_size )
   if( found_int == 1 ) then
     call c_f_pointer(value_cptr,value_fptr,(/value_size/))
@@ -958,7 +958,7 @@ function get_array_string(this,name,value) result(found)
   integer(c_size_t) :: elemlen
   integer(c_size_t) :: j
   character(len=:), allocatable :: flatvalue
-  found_int =   c_fckit_configuration_get_array_string(this%CPTR_PGIBUG_B, c_str(name), &
+  found_int =   c_fckit_configuration_get_array_string(this%c_ptr(), c_str(name), &
    & value_cptr, value_size, offsets_cptr, value_numelem)
   if( found_int == 1 ) then
     ! Get flat character array
@@ -1010,7 +1010,7 @@ function json(this) result(jsonstr)
   class(fckit_Configuration), intent(in) :: this
   type(c_ptr) :: json_cptr
   integer(c_size_t) :: json_size
-  call c_fckit_configuration_json(this%CPTR_PGIBUG_B,json_cptr,json_size)
+  call c_fckit_configuration_json(this%c_ptr(),json_cptr,json_size)
   FCKIT_ALLOCATE_CHARACTER(jsonstr,json_size)
   jsonstr = c_ptr_to_string(json_cptr)
   call c_ptr_free(json_cptr)

--- a/src/fckit/module/fckit_exception.F90
+++ b/src/fckit/module/fckit_exception.F90
@@ -200,7 +200,7 @@ function what()
   integer(c_int32_t) :: error_code
 
   error_code = fckit__exception_what(what_c_ptr,what_size)
-  FCKIT_ALLOCATE_CHARACTER(what,what_size)
+  allocate( character(len=(what_size),kind=c_char) :: what )
   what = c_ptr_to_string(what_c_ptr)
   call c_ptr_free(what_c_ptr)
 end function
@@ -236,7 +236,7 @@ function location_file() result(file)
   integer(c_int32_t) :: error_code
 
   error_code = fckit__exception_file(file_c_ptr,file_size)
-  FCKIT_ALLOCATE_CHARACTER(file,file_size)
+  allocate( character(len=(file_size),kind=c_char) :: file )
   file = c_ptr_to_string(file_c_ptr)
   call c_ptr_free(file_c_ptr)
 end function
@@ -269,7 +269,7 @@ function location_function() result(function)
   integer(c_int32_t) :: error_code
 
   error_code = fckit__exception_function(function_c_ptr,function_size)
-  FCKIT_ALLOCATE_CHARACTER(function,function_size)
+  allocate( character(len=(function_size),kind=c_char) :: function )
   function = c_ptr_to_string(function_c_ptr)
   call c_ptr_free(function_c_ptr)
 end function
@@ -290,7 +290,7 @@ function callstack()
   integer(c_int32_t) :: error_code
 
   error_code = fckit__exception_callstack(callstack_c_ptr,callstack_size)
-  FCKIT_ALLOCATE_CHARACTER(callstack,callstack_size)
+  allocate( character(len=(callstack_size),kind=c_char) :: callstack )
   callstack = c_ptr_to_string(callstack_c_ptr)
   call c_ptr_free(callstack_c_ptr)
 end function

--- a/src/fckit/module/fckit_main.F90
+++ b/src/fckit/module/fckit_main.F90
@@ -208,7 +208,7 @@ subroutine main_name(name)
   integer(c_size_t) :: name_size
   integer(c_int32_t) :: error_code
   error_code = fckit__main_name(name_c_ptr,name_size)
-  FCKIT_ALLOCATE_CHARACTER(name,name_size)
+  allocate( character(len=(name_size),kind=c_char) :: name )
   name = c_ptr_to_string(name_c_ptr)
   call c_ptr_free(name_c_ptr)
 end subroutine
@@ -222,7 +222,7 @@ subroutine displayname(name)
   integer(c_size_t) :: name_size
   integer(c_int32_t) :: error_code
   error_code = fckit__main_displayname(name_c_ptr,name_size)
-  FCKIT_ALLOCATE_CHARACTER(name,name_size)
+  allocate( character(len=(name_size),kind=c_char) :: name )
   name = c_ptr_to_string(name_c_ptr)
   call c_ptr_free(name_c_ptr)
 end subroutine

--- a/src/fckit/module/fckit_mpi.fypp
+++ b/src/fckit/module/fckit_mpi.fypp
@@ -688,7 +688,7 @@ end function
 subroutine delete(this)
   use fckit_c_interop_module
   class(fckit_mpi_comm), intent(inout) :: this
-  call fckit__mpi__comm_delete(this%CPTR_PGIBUG_A)
+  call fckit__mpi__comm_delete(this%c_ptr())
   call this%reset_c_ptr()
 end subroutine
 
@@ -703,7 +703,7 @@ function split( this, colour, name )
   integer(c_int32_t), intent(in) :: colour
   character(len=*) :: name
   call split%reset_c_ptr( &
-      & fckit__mpi__comm_split( this%CPTR_PGIBUG_A, colour, c_str(name) ) )
+      & fckit__mpi__comm_split( this%c_ptr(), colour, c_str(name) ) )
   call split%return()
 end function
 
@@ -716,7 +716,7 @@ function name(this)
   character(len=:), allocatable :: name
   type(c_ptr) :: name_c_ptr
   integer(c_int32_t) :: name_size
-  call fckit__mpi__comm_name( this%CPTR_PGIBUG_A, name_c_ptr, name_size )
+  call fckit__mpi__comm_name( this%c_ptr(), name_c_ptr, name_size )
   allocate(character(len=name_size) :: name )
   name = c_ptr_to_string(name_c_ptr)
   call c_ptr_free(name_c_ptr)
@@ -726,7 +726,7 @@ end function
 
 subroutine set_default(this)
   class(fckit_mpi_comm), intent(inout) :: this
-  call fckit__mpi__comm_set_default( this%CPTR_PGIBUG_A )
+  call fckit__mpi__comm_set_default( this%c_ptr() )
 end subroutine
 
 !---------------------------------------------------------------------------------------
@@ -735,7 +735,7 @@ function communicator(this)
   use, intrinsic :: iso_c_binding, only : c_int32_t
   integer(c_int32_t) :: communicator
   class(fckit_mpi_comm), intent(in) :: this
-  communicator = fckit__mpi__comm_communicator(this%CPTR_PGIBUG_A)
+  communicator = fckit__mpi__comm_communicator(this%c_ptr())
 end function
 
 !---------------------------------------------------------------------------------------
@@ -744,7 +744,7 @@ function fckit_mpi__rank(this) result(rank)
   use, intrinsic :: iso_c_binding, only : c_int32_t
   integer(c_int32_t) :: rank
   class(fckit_mpi_comm), intent(in) :: this
-  rank = fckit__mpi__rank(this%CPTR_PGIBUG_A)
+  rank = fckit__mpi__rank(this%c_ptr())
 end function
 
 !---------------------------------------------------------------------------------------
@@ -753,7 +753,7 @@ function fckit_mpi__size(this) result(size)
   use, intrinsic :: iso_c_binding, only : c_int32_t
   integer(c_int32_t) :: size
   class(fckit_mpi_comm), intent(in) :: this
-  size = fckit__mpi__size(this%CPTR_PGIBUG_A)
+  size = fckit__mpi__size(this%c_ptr())
 end function
 
 !---------------------------------------------------------------------------------------
@@ -762,7 +762,7 @@ function anytag(this)
   use, intrinsic :: iso_c_binding, only : c_int32_t
   integer(c_int32_t) :: anytag
   class(fckit_mpi_comm), intent(in) :: this
-  anytag = fckit__mpi__anytag(this%CPTR_PGIBUG_A)
+  anytag = fckit__mpi__anytag(this%c_ptr())
 end function
 
 !---------------------------------------------------------------------------------------
@@ -771,14 +771,14 @@ function anysource(this)
   use, intrinsic :: iso_c_binding, only : c_int32_t
   integer(c_int32_t) :: anysource
   class(fckit_mpi_comm), intent(in) :: this
-  anysource = fckit__mpi__anysource(this%CPTR_PGIBUG_A)
+  anysource = fckit__mpi__anysource(this%c_ptr())
 end function
 
 !---------------------------------------------------------------------------------------
 
 subroutine barrier(this)
   class(fckit_mpi_comm), intent(in) :: this
-  call fckit__mpi__barrier(this%CPTR_PGIBUG_A)
+  call fckit__mpi__barrier(this%c_ptr())
 end subroutine
 
 !---------------------------------------------------------------------------------------
@@ -788,9 +788,9 @@ subroutine fckit_mpi__abort(this,error_code)
   class(fckit_mpi_comm), intent(in) :: this
   integer(c_int32_t), intent(in), optional :: error_code
   if( present(error_code) ) then
-    call fckit__mpi__abort(this%CPTR_PGIBUG_A,error_code)
+    call fckit__mpi__abort(this%c_ptr(),error_code)
   else
-    call fckit__mpi__abort(this%CPTR_PGIBUG_A,-1)
+    call fckit__mpi__abort(this%c_ptr(),-1)
   endif
 end subroutine
 
@@ -811,7 +811,7 @@ subroutine allgather_${dtype}$_r0(this,in,out)
   ${btype}$ :: mold
   view_in => array_view1d(in,mold)
   view_out => array_view1d(out,mold)
-  call fckit__mpi__allgather_${dtype}$(this%CPTR_PGIBUG_A,view_in(1),view_out)
+  call fckit__mpi__allgather_${dtype}$(this%c_ptr(),view_in(1),view_out)
 end subroutine
 
 !---------------------------------------------------------------------------------------
@@ -885,7 +885,7 @@ subroutine allgather_${dtype}$_r${rank}$(this,in,out,sendcount)
   view_out => array_view1d(out,mold)
   view_rc => array_view1d(recvcounts)
   view_dp => array_view1d(displs)
-  call fckit__mpi__allgatherv_${dtype}$(this%CPTR_PGIBUG_A,view_in,view_out,int(sendcount,c_size_t),view_rc,view_dp)
+  call fckit__mpi__allgatherv_${dtype}$(this%c_ptr(),view_in,view_out,int(sendcount,c_size_t),view_rc,view_dp)
   deallocate(recvcounts,displs)
 end subroutine
 
@@ -907,7 +907,7 @@ subroutine allgatherv_${dtype}$_r${rank}$(this,in,out,sendcount,recvcounts,displ
   view_out => array_view1d(out,mold)
   view_rc => array_view1d(recvcounts)
   view_dp => array_view1d(displs)
-  call fckit__mpi__allgatherv_${dtype}$(this%CPTR_PGIBUG_A,view_in,view_out,int(sendcount,c_size_t),view_rc,view_dp)
+  call fckit__mpi__allgatherv_${dtype}$(this%c_ptr(),view_in,view_out,int(sendcount,c_size_t),view_rc,view_dp)
 end subroutine
 
 !---------------------------------------------------------------------------------------
@@ -930,7 +930,7 @@ subroutine alltoallv_${dtype}$_r${rank}$(this,in,scounts,sdispl,out,rcounts,rdis
   view_sd => array_view1d(sdispl)
   view_rc => array_view1d(rcounts)
   view_rd => array_view1d(rdispl)
-  call fckit__mpi__alltoallv_${dtype}$(this%CPTR_PGIBUG_A,view_in,view_sc,view_sd,view_out,view_rc,view_rd)
+  call fckit__mpi__alltoallv_${dtype}$(this%c_ptr(),view_in,view_sc,view_sd,view_out,view_rc,view_rd)
 end subroutine
 
 !---------------------------------------------------------------------------------------
@@ -963,7 +963,7 @@ subroutine broadcast_string(this,buffer,root)
      enddo
      c_string(len(buffer)+1) = c_null_char
   endif
-  call fckit__mpi__broadcast_string(this%CPTR_PGIBUG_A,c_string,int(len(buffer)+1,c_size_t),int(root,c_size_t))
+  call fckit__mpi__broadcast_string(this%c_ptr(),c_string,int(len(buffer)+1,c_size_t),int(root,c_size_t))
   do j=1,len(buffer)
      buffer(j:j) = c_string(j)
   enddo
@@ -987,7 +987,7 @@ function broadcast_file(this,path,root) result(buffer)
   integer(c_int32_t), intent(in) :: root
     !! MPI rank that reads and broadcasts file
 
-  buffer = fckit_buffer( fckit__mpi__broadcast_file(this%CPTR_PGIBUG_A,c_str(path),int(root,c_size_t)), share=.true. )
+  buffer = fckit_buffer( fckit__mpi__broadcast_file(this%c_ptr(),c_str(path),int(root,c_size_t)), share=.true. )
   call buffer%return()
 end function
 
@@ -1017,7 +1017,7 @@ subroutine allreduce_${dtype}$_r${rank}$(this,in,out,operation)
   ${btype}$ :: mold
   view_in  => array_view1d(in,mold)
   view_out => array_view1d(out,mold)
-  call fckit__mpi__allreduce_${dtype}$(this%CPTR_PGIBUG_A,view_in,view_out, &
+  call fckit__mpi__allreduce_${dtype}$(this%c_ptr(),view_in,view_out, &
     int(ubound(view_in,1),c_size_t),operation)
 end subroutine
 
@@ -1039,7 +1039,7 @@ subroutine allreduce_inplace_${dtype}$_r${rank}$(this,inout,operation)
   ${btype}$, pointer :: view_inout(:)
   ${btype}$ :: mold
   view_inout => array_view1d(inout,mold)
-  call fckit__mpi__allreduce_inplace_${dtype}$(this%CPTR_PGIBUG_A,view_inout, &
+  call fckit__mpi__allreduce_inplace_${dtype}$(this%c_ptr(),view_inout, &
     int(ubound(view_inout,1),c_size_t),operation)
 end subroutine
 
@@ -1061,7 +1061,7 @@ subroutine broadcast_${dtype}$_r${rank}$(this,buffer,root)
   ${btype}$, pointer :: view_buffer(:)
   ${btype}$ :: mold
   view_buffer  => array_view1d(buffer,mold)
-  call fckit__mpi__broadcast_${dtype}$(this%CPTR_PGIBUG_A,view_buffer, &
+  call fckit__mpi__broadcast_${dtype}$(this%c_ptr(),view_buffer, &
     int(ubound(view_buffer,1),c_size_t),int(root,c_size_t))
 end subroutine
 
@@ -1085,7 +1085,7 @@ subroutine send_${dtype}$_r${rank}$(this,buffer,dest,tag)
   ${btype}$, pointer :: view_buffer(:)
   ${btype}$ :: mold
   view_buffer  => array_view1d(buffer,mold)
-  call fckit__mpi__send_${dtype}$(this%CPTR_PGIBUG_A,view_buffer, &
+  call fckit__mpi__send_${dtype}$(this%c_ptr(),view_buffer, &
     int(ubound(view_buffer,1),c_size_t),dest,tag)
 end subroutine
 
@@ -1115,10 +1115,10 @@ subroutine receive_${dtype}$_r${rank}$(this,buffer,source,tag,status)
   if( present(tag) ) then
     tag_opt = tag
   else
-    tag_opt = fckit__mpi__anytag(this%CPTR_PGIBUG_A)
+    tag_opt = fckit__mpi__anytag(this%c_ptr())
   endif
   view_buffer  => array_view1d(buffer,mold)
-  call fckit__mpi__receive_${dtype}$(this%CPTR_PGIBUG_A,view_buffer, &
+  call fckit__mpi__receive_${dtype}$(this%c_ptr(),view_buffer, &
     int(ubound(view_buffer,1),c_size_t),source,tag_opt,status_out%status)
   if( present(status) ) status = status_out
 end subroutine
@@ -1146,7 +1146,7 @@ function isend_${dtype}$_r${rank}$(this,buffer,dest,tag) result(request)
   ${btype}$, pointer :: view_buffer(:)
   ${btype}$ :: mold
   view_buffer  => array_view1d(buffer,mold)
-  request = fckit__mpi__isend_${dtype}$(this%CPTR_PGIBUG_A,view_buffer, &
+  request = fckit__mpi__isend_${dtype}$(this%c_ptr(),view_buffer, &
     int(ubound(view_buffer,1),c_size_t),dest,tag)
 end function
 
@@ -1176,10 +1176,10 @@ function ireceive_${dtype}$_r${rank}$(this,buffer,source,tag) result(request)
   if( present(tag) ) then
     tag_opt = tag
   else
-    tag_opt = fckit__mpi__anytag(this%CPTR_PGIBUG_A)
+    tag_opt = fckit__mpi__anytag(this%c_ptr())
   endif
   view_buffer  => array_view1d(buffer,mold)
-  request = fckit__mpi__ireceive_${dtype}$(this%CPTR_PGIBUG_A,view_buffer, &
+  request = fckit__mpi__ireceive_${dtype}$(this%c_ptr(),view_buffer, &
     int(ubound(view_buffer,1),c_size_t),source,tag_opt)
 end function
 
@@ -1203,7 +1203,7 @@ subroutine wait(this,request,status)
     !! MPI status
 
   type(fckit_mpi_status) :: status_out
-  call fckit__mpi__wait(this%CPTR_PGIBUG_A,request,status_out%status)
+  call fckit__mpi__wait(this%c_ptr(),request,status_out%status)
   if( present(status) ) status = status_out
 end subroutine
 

--- a/src/fckit/module/fckit_object.F90
+++ b/src/fckit/module/fckit_object.F90
@@ -27,11 +27,7 @@ public fckit_object
 type, extends(fckit_final) :: fckit_object
   !! Abstract base class for objects that wrap a C++ object
 
-#if !PGIBUG_ATLAS_197
   type(c_ptr), private :: cpp_object_ptr = c_null_ptr
-#else
-  type(c_ptr), public :: cpp_object_ptr = c_null_ptr
-#endif
 
   type(c_funptr), private :: deleter = c_null_funptr
     !! Internal C pointer
@@ -43,10 +39,8 @@ contains
   procedure, public :: is_null
     !! Check if internal C pointer is set
 
-#if !PGIBUG_ATLAS_197
   procedure, public :: c_ptr   => fckit_object__c_ptr
     !! Access to internal C pointer
-#endif
 
   procedure, public :: reset_c_ptr
     !! Nullify internal C pointer

--- a/src/fckit/module/fckit_owned_object.F90
+++ b/src/fckit/module/fckit_owned_object.F90
@@ -35,11 +35,7 @@ public fckit_owned_object
 type :: fckit_owned_object
   !! Abstract base class for objects that wrap a C++ object
 
-#if !PGIBUG_ATLAS_197
   type(c_ptr), private :: cpp_object_ptr = c_null_ptr
-#else
-  type(c_ptr), public :: cpp_object_ptr = c_null_ptr
-#endif
   type(c_funptr), private :: deleter = c_null_funptr
     !! Internal C pointer
 
@@ -50,10 +46,8 @@ contains
   procedure, public :: is_null
     !! Check if internal C pointer is set
 
-#if !PGIBUG_ATLAS_197_DEBUG
   procedure, public :: c_ptr   => fckit_owned_object__c_ptr
     !! Access to internal C pointer
-#endif
 
   procedure, public :: reset_c_ptr
     !! Nullify internal C pointer

--- a/src/fckit/module/fckit_pathname.F90
+++ b/src/fckit/module/fckit_pathname.F90
@@ -56,7 +56,7 @@ function fckit_pathname__str(this) result(str)
   class(fckit_pathname) :: this
   integer(c_int32_t) :: i, nchars
   nchars = size(this%string)
-  FCKIT_ALLOCATE_CHARACTER(str,nchars)
+  allocate( character(len=(nchars),kind=c_char) :: str )
   do i=1,nchars
     str(i:i) = this%string(i)
   enddo

--- a/src/fckit/module/fckit_refcount.F90
+++ b/src/fckit/module/fckit_refcount.F90
@@ -128,7 +128,7 @@ subroutine allocate_fckit_refcount_owned(refcount,shared_ptr)
   allocate( fckit_refcount_owned::refcount )
   select type( shared_ptr )
     class is( fckit_object )
-      cptr = shared_ptr%CPTR_PGIBUG_A
+      cptr = shared_ptr%c_ptr()
   end select
   select type( refcount )
     class is( fckit_refcount_owned )

--- a/src/fckit/module/fckit_resource.F90
+++ b/src/fckit/module/fckit_resource.F90
@@ -138,7 +138,7 @@ subroutine resource_get_string(resource_str,default_value,value)
   integer(c_size_t) :: value_size
   integer(c_int32_t) :: error_code
   error_code = fckit__resource_string(c_str(resource_str),c_str(default_value),value_c_ptr,value_size)
-  FCKIT_ALLOCATE_CHARACTER(value,value_size)
+  allocate( character(len=(value_size),kind=c_char) :: value )
   value = c_ptr_to_string(value_c_ptr)
   call c_ptr_free(value_c_ptr)
 end subroutine

--- a/src/fckit/module/fckit_shared_object.F90
+++ b/src/fckit/module/fckit_shared_object.F90
@@ -46,9 +46,7 @@ contains
 
   procedure, public :: reset_c_ptr
 
-#if !PGIBUG_ATLAS_197_DEBUG
   procedure, public  :: c_ptr => fckit_shared_object_c_ptr
-#endif
 
   procedure, private :: fckit_shared_object_c_ptr
 
@@ -145,7 +143,7 @@ function fckit_shared_object_c_ptr(this) result(cptr)
   use, intrinsic :: iso_c_binding, only : c_ptr
   type(c_ptr) :: cptr
   class(fckit_shared_object) :: this
-  cptr = this%shared_object_%CPTR_PGIBUG_A
+  cptr = this%shared_object_%c_ptr()
 end function
 
 end module

--- a/src/tests/test_shared_ptr.F90
+++ b/src/tests/test_shared_ptr.F90
@@ -128,7 +128,7 @@ end function
 function ObjectCXX_id(this) result(id)
   class(ObjectCXX) :: this
   integer :: id
-  id = Object__id( this%CPTR_PGIBUG_B )
+  id = Object__id( this%c_ptr() )
 end function
 
 FCKIT_FINAL subroutine ObjectCXX_final_auto(this)


### PR DESCRIPTION
This pull request removes workarounds for old compiler bugs (specifically for PGI/NVHPC and XL Fortran), and simplifies the code by eliminating related macros and conditional logic. All code now consistently uses the standard `c_ptr()` method and direct Fortran allocation syntax for character variables, improving maintainability and clarity.

The most important changes are:

**Removal of compiler bug workarounds:**
* Removed all logic and macros related to the `PGIBUG_ATLAS_197` workaround for PGI/NVHPC compilers, including conditional use of `CPTR_PGIBUG_A/B` and related preprocessor logic in both the CMake configuration and Fortran header/template files. 
* Removed the workaround macro `FCKIT_ALLOCATE_CHARACTER` and the associated XL Fortran bug logic, replacing all usages with direct Fortran allocation using `character(len=...,kind=c_char)`.

**Code simplification and modernization:**
* Updated all Fortran code to use the standard `c_ptr()` member function directly instead of the workaround macros, ensuring consistent pointer handling throughout the codebase.
* Replaced all usages of the removed macros with direct allocation syntax for character variables, improving code clarity and reducing reliance on preprocessor directives. 

These changes collectively modernize the codebase by removing legacy support for obsolete compiler bugs and making the code simpler and easier to maintain.