### PR TITLE
Fix expansion of property lists in fckit_preprocess_fypp_sources

### DIFF
--- a/cmake/fckit_preprocess_fypp.cmake
+++ b/cmake/fckit_preprocess_fypp.cmake
@@ -156,7 +156,7 @@ function( fckit_preprocess_fypp_sources output )
                    OVERRIDE_COMPILE_FLAGS_${CMAKE_BUILD_TYPE_CAPS} )
       get_source_file_property( ${filename}_${_prop} ${filename} ${_prop} )
       if( ${filename}_${_prop} )
-        set_source_files_properties(${outfile} PROPERTIES ${_prop} ${${filename}_${_prop}} )
+        set_source_files_properties(${outfile} PROPERTIES ${_prop} "${${filename}_${_prop}}" )
       endif()
     endforeach()
 

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -157,6 +157,7 @@ endforeach()
 ### Test downstream find_package(fckit) projects
 add_subdirectory( test_downstream_fypp )
 add_subdirectory( test_downstream_fctest )
+add_subdirectory( test_downstream_fypp_list_options )
 
 ### Test fckit_yaml_reader
 if( HAVE_FCKIT_VENV )

--- a/src/tests/test_downstream_fypp_list_options/CMakeLists.txt
+++ b/src/tests/test_downstream_fypp_list_options/CMakeLists.txt
@@ -1,0 +1,28 @@
+
+# This test configures a downstream package that calls fckit_preprocess_fypp_sources
+# with a list-valued COMPILE_OPTIONS property set on an fypp source file.
+#
+# Test created in response to a bug where source file properties were being
+# expanded unquoted, resulting in a CMake configuration error.
+
+if( HAVE_TESTS )
+
+  configure_file( test-downstream.sh.in ${CMAKE_CURRENT_BINARY_DIR}/test-downstream.sh @ONLY )
+
+  unset( _test_args )
+  if( CMAKE_TOOLCHAIN_FILE )
+    if( NOT IS_ABSOLUTE ${CMAKE_TOOLCHAIN_FILE})
+      set( CMAKE_TOOLCHAIN_FILE "${CMAKE_BINARY_DIR}/${CMAKE_TOOLCHAIN_FILE}" )
+    endif()
+    list( APPEND _test_args "-DCMAKE_TOOLCHAIN_FILE=${CMAKE_TOOLCHAIN_FILE}" )
+  endif()
+  foreach( lang C CXX Fortran )
+    if( CMAKE_${lang}_COMPILER )
+      list( APPEND _test_args "-DCMAKE_${lang}_COMPILER=${CMAKE_${lang}_COMPILER}" )
+    endif()
+  endforeach()
+
+  add_test( NAME fckit_test_downstream_fypp_list_options
+            COMMAND ${CMAKE_CURRENT_BINARY_DIR}/test-downstream.sh ${_test_args} )
+
+endif()

--- a/src/tests/test_downstream_fypp_list_options/downstream/CMakeLists.txt
+++ b/src/tests/test_downstream_fypp_list_options/downstream/CMakeLists.txt
@@ -1,0 +1,15 @@
+cmake_minimum_required( VERSION 3.12 FATAL_ERROR )
+
+find_package( ecbuild REQUIRED )
+
+project( downstream_fypp_list_options VERSION 0.1.0 LANGUAGES Fortran )
+
+find_package( fckit REQUIRED )
+
+# Set COMPILE_OPTIONS to a multi-element CMake list:
+set_source_files_properties( test_source.fypp
+    PROPERTIES COMPILE_OPTIONS "-DFOO;-DBAR" )
+
+unset( _output_sources )
+fckit_preprocess_fypp_sources( _output_sources
+    SOURCES test_source.fypp )

--- a/src/tests/test_downstream_fypp_list_options/downstream/test_source.fypp
+++ b/src/tests/test_downstream_fypp_list_options/downstream/test_source.fypp
@@ -1,0 +1,10 @@
+! Minimal fypp source used by test_downstream_fypp_list_options.
+! This file is not built; it exists only so that fckit_preprocess_fypp_sources
+! has a real source path to register in add_custom_command.
+module test_source
+implicit none
+contains
+subroutine hello()
+  write(0,*) "hello"
+end subroutine
+end module

--- a/src/tests/test_downstream_fypp_list_options/test-downstream.sh.in
+++ b/src/tests/test_downstream_fypp_list_options/test-downstream.sh.in
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+
+# Description:
+#   Configure a downstream project that calls fckit_preprocess_fypp_sources
+#   with a list-valued COMPILE_OPTIONS property on a fypp source file.
+#
+# Usage:
+#   test-downstream.sh [CMAKE_ARGUMENTS]
+
+SOURCE=@CMAKE_CURRENT_SOURCE_DIR@/downstream
+BUILD_ROOT=@CMAKE_CURRENT_BINARY_DIR@
+
+function test_failed {
+  EXIT_CODE=$?
+  { set +ex; } 2>/dev/null
+  if [ $EXIT_CODE -ne 0 ]; then
+    echo "+++++++++++++++++"
+    echo "Test failed"
+    echo "+++++++++++++++++"
+  fi
+  exit $EXIT_CODE
+}
+trap test_failed EXIT
+set -e -o pipefail
+set -x
+
+export fckit_DIR=@PROJECT_BINARY_DIR@
+export ecbuild_DIR=@ecbuild_DIR@
+
+COMMON_CMAKE_ARGS=(
+  -DCMAKE_BUILD_TYPE=RelWithDebInfo
+  -DECBUILD_2_COMPAT=OFF
+  "$@"
+)
+
+build_dir=${BUILD_ROOT}/downstream
+rm -rf "$build_dir"
+mkdir -p "$build_dir"
+cd "$build_dir"
+
+cmake "$SOURCE" "${COMMON_CMAKE_ARGS[@]}"
+
+{ set +ex; } 2>/dev/null
+echo "+++++++++++++++++"
+echo "Test passed"
+echo "+++++++++++++++++"


### PR DESCRIPTION
### Description

If `fckit_preprocess_fypp_sources` is given multiple properties as a CMake list, rather than as a string, then the `set_source_file_properties` call expands them into separate arguments and immediately fails because there are more arguments than expected. This is most likely to happen with the more modern COMPILE_OPTIONS property which is managed as a list, rather than COMPILE_FLAGS-type strings.

The argument is quoted to prevent expansion, and a new test added to catch this use case.

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 
