### PR TITLE
 Fix race condition when installing fckit_yaml_reader from a shared source tree

### DIFF
--- a/cmake/fckit_install_venv.cmake
+++ b/cmake/fckit_install_venv.cmake
@@ -59,8 +59,25 @@ macro( fckit_install_venv )
     # install virtual environment from requirements, which includes fypp
     set( _pkg_name "fckit_yaml_reader")
     ecbuild_info( "Install fckit_yaml_reader and fypp in virtual environment ${VENV_PATH}" )
+
+    # Stage the package into the build tree so concurrent builds sharing the same
+    # source checkout don't race on setuptools' in-tree build/ and *.egg-info/ dirs.
+    set( _pkg_src "${CMAKE_CURRENT_SOURCE_DIR}/src/fckit/${_pkg_name}" )
+    set( _pkg_bld "${CMAKE_CURRENT_BINARY_DIR}/${_pkg_name}" )
+    file( REMOVE_RECURSE "${_pkg_bld}" )
+    file( COPY "${_pkg_src}/" DESTINATION "${_pkg_bld}"
+          PATTERN "build"       EXCLUDE
+          PATTERN "*.egg-info"  EXCLUDE
+          PATTERN "dist"        EXCLUDE
+          PATTERN "__pycache__" EXCLUDE )
+
     execute_process( COMMAND ${Python3_EXECUTABLE} -m pip
-                     install ${PIP_OPTIONS} ${CMAKE_CURRENT_SOURCE_DIR}/src/fckit/${_pkg_name} OUTPUT_QUIET )
+                     install ${PIP_OPTIONS} "${_pkg_bld}"
+                     RESULT_VARIABLE _pip_result
+                     OUTPUT_QUIET )
+    if( NOT _pip_result EQUAL 0 )
+        ecbuild_error( "pip install of ${_pkg_name} failed (exit ${_pip_result})" )
+    endif()
 
     if( HAVE_FCKIT_VENV_INSTALL )
        install( DIRECTORY ${VENV_PATH} DESTINATION . PATTERN "bin/*" PERMISSIONS ${install_permissions} )
@@ -90,4 +107,3 @@ macro( fckit_install_venv )
     set( Python3_EXECUTABLE ${Python3_EXECUTABLE_CACHE} )
 
 endmacro()
-


### PR DESCRIPTION
### Description

fixes issue https://github.com/ecmwf/fckit/issues/101

`fckit_yaml_reader` was installed by running `pip install` directly against `${CMAKE_CURRENT_SOURCE_DIR}/src/fckit/fckit_yaml_reader`. Because setuptools performs the wheel build in-tree, it writes `build/`, `*.egg-info/`, and `dist/` into the shared source directory. When multiple fckit builds run concurrently from the same source checkout (e.g. an HPC toolchain matrix producing several build trees in parallel), these builds race on the same paths, producing intermittent failures such as:

```
removing 'build/bdist.linux-x86_64/wheel/./fckit_yaml_reader-0.0.1-py3.10.egg-info' (and everything under it)
...
error: [Errno 2] No such file or directory
ERROR: Failed building wheel for fckit_yaml_reader
```

This PR stages the package into `${CMAKE_CURRENT_BINARY_DIR}/fckit_yaml_reader` before invoking pip, so each build tree gets its own private copy and no longer writes into the shared source tree. Stale `build/`, `*.egg-info/`, `dist/`, and `__pycache__/` directories are excluded from the copy to avoid propagating artefacts from previously-polluted checkouts.

The `execute_process` call also gains a `RESULT_VARIABLE` check and an `ecbuild_error` on failure, so future pip failures are no longer silently hidden by `OUTPUT_QUIET`.

No other behaviour is changed: `PIP_OPTIONS`, `ARTIFACTS_DIR`, `HAVE_FCKIT_VENV_EDITABLE`, and the install/symlink logic all work as before.

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 
