### PR TITLE
Make eckit_DIR explicit in fckit_test_downstream_* tests

### DIFF
--- a/src/tests/test_downstream_fctest/test-downstream.sh.in
+++ b/src/tests/test_downstream_fctest/test-downstream.sh.in
@@ -29,6 +29,7 @@ set -x
 rm -rf $BUILD
 
 export fckit_DIR=@PROJECT_BINARY_DIR@
+export eckit_DIR=@eckit_DIR@
 export ecbuild_DIR=@ecbuild_DIR@
 
 # Build

--- a/src/tests/test_downstream_fypp/test-downstream.sh.in
+++ b/src/tests/test_downstream_fypp/test-downstream.sh.in
@@ -26,6 +26,7 @@ set -e -o pipefail
 set -x
 
 export fckit_DIR=@PROJECT_BINARY_DIR@
+export eckit_DIR=@eckit_DIR@
 export ecbuild_DIR=@ecbuild_DIR@
 
 COMMON_CMAKE_ARGS=(

--- a/src/tests/test_downstream_fypp_list_options/test-downstream.sh.in
+++ b/src/tests/test_downstream_fypp_list_options/test-downstream.sh.in
@@ -25,6 +25,7 @@ set -e -o pipefail
 set -x
 
 export fckit_DIR=@PROJECT_BINARY_DIR@
+export eckit_DIR=@eckit_DIR@
 export ecbuild_DIR=@ecbuild_DIR@
 
 COMMON_CMAKE_ARGS=(


### PR DESCRIPTION
### Description

Fix for issue #95 where the found eckit in fckit_test_downstream_fypp was not the one used by fckit.

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 
