### PR TITLE
Add retries to fckit_yaml_reader pip installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,25 +43,32 @@ Various Fortran modules helpful to create mixed-language applications
 
 ### Offline build of fckit Python virtual environment
 
-An offline build/installation of the fckit Python virtual environment can be completed as follows:
+1. On a networked machine, create a complete wheelhouse in `<source-dir>/artifacts`:
 
-1. Download all necessary Python dependencies of src/fckit/fckit_yaml_reader. `ruamel.yaml.clib`
-is not a pure Python package, so we have to ensure a wheel compatible with the target platform is
-downloaded. pip compatibility tags for any system can be displayed using `python3 -m pip debug --verbose`,
-and buit-distributions (i.e. wheels) for ruamel.yaml.clib can be found [here](https://pypi.org/project/ruamel.yaml.clib/#files).
-For a linux installation based on an x86 architecture using Python3.10, the following command can be used:
+```
+./populate
+```
+
+By default, wheels are downloaded for the calling system and Python interpreter. For a different
+target, specify compatible platform and Python versions. For example, for Python 3.10 on Linux x86-64:
 
 ```
 FCKIT_WHEEL_ARCH=manylinux_2_17_x86_64 FCKIT_WHEEL_PYTHON_VERSION=310 ./populate
 ```
 
-This will download all the wheels to `<source-dir>/artifacts.` It should
-be noted that if `FCKIT_WHEEL_ARCH` and `FCKIT_WHEEL_PYTHON_VERSION`
-are not specified then the wheels are downloaded for the calling system's Python interpreter.
+`ruamel.yaml.clib` contains platform-specific code, so these values must match the target. Available
+compatibility tags can be inspected with `python3 -m pip debug --verbose`.
 
-2. scp/rsync/copy the directory containing the dependencies to the offline system.
+2. Copy the `artifacts` directory to the offline system.
 
-3. Add the path to the `artifacts` directory to the fckit CMake configuration step, i.e. `-DARTIFACTS_DIR=<path-to-artifacts-dir>`.
+3. Pass its location when configuring fckit:
+
+```
+cmake ... -DARTIFACTS_DIR=<path-to-artifacts-dir>
+```
+
+This makes pip install exclusively from the wheelhouse using `--no-index --find-links`, without
+contacting a package index.
 
 ### License
 

--- a/cmake/fckit_install_venv.cmake
+++ b/cmake/fckit_install_venv.cmake
@@ -36,7 +36,7 @@ macro( fckit_install_venv )
     if( DEFINED ARTIFACTS_DIR )
         list( APPEND PIP_OPTIONS "--no-index;--find-links=${ARTIFACTS_DIR}" )
     else()
-        list( APPEND PIP_OPTIONS "--disable-pip-version-check")
+        list( APPEND PIP_OPTIONS "--disable-pip-version-check;--retries=5" )
     endif()
 
     if( HAVE_FCKIT_VENV_EDITABLE )


### PR DESCRIPTION
This PR addresses the outstanding issues highlighted in #97. Specifically:
1. The `--retries=5` option is added to the pip installation, so as to counteract intermittent network issues during pip installs rather than immediately causing the whole configuration step to fail.
2. The procedure for doing offline fckit_yaml_reader builds is clarified.
 
